### PR TITLE
Ghostery extension integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,7 @@ def configureWorkspace() {
             sh "./fern.sh use ${FIREFOX_VERSION}"
             sh "./fern.sh reset ${FIREFOX_VERSION}"
             sh './fern.sh import-patches'
+            sh './bootstrap_extension.sh'
         }
 
         stage('prepare build env') {

--- a/bootstrap_extension.sh
+++ b/bootstrap_extension.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+VERSION=v8.5.2
+
+wget https://github.com/ghostery/ghostery-extension/releases/download/$VERSION/ghostery-firefox-$VERSION.zip
+mkdir -p mozilla-release/browser/extensions/ghostery
+mv ghostery-firefox-$VERSION.zip mozilla-release/browser/extensions/ghostery/
+( cd mozilla-release/browser/extensions/ghostery/ && \
+  unzip ghostery-firefox-$VERSION.zip && \
+  rm ghostery-firefox-$VERSION.zip
+)

--- a/patches/.index
+++ b/patches/.index
@@ -1,2 +1,3 @@
-0001-Fix-Mac-packaging-when-using-a-non-firefox-app-name.patch
+0003-Add-moz.build-for-ghostery-extension.patch
 0002-Specify-correct-executable-in-Mac-Info.plist.patch
+0001-Fix-Mac-packaging-when-using-a-non-firefox-app-name.patch

--- a/patches/0003-Add-moz.build-for-ghostery-extension.patch
+++ b/patches/0003-Add-moz.build-for-ghostery-extension.patch
@@ -1,0 +1,379 @@
+From 66705df64bccfe56575b51f54801bc860aa4549b Mon Sep 17 00:00:00 2001
+From: Sam Macbeth <sam@cliqz.com>
+Date: Thu, 6 Aug 2020 15:24:30 +0200
+Subject: [PATCH] Add moz.build for ghostery extension
+
+Signed-off-by: Sam Macbeth <sam@cliqz.com>
+---
+ browser/extensions/ghostery/moz.build | 346 ++++++++++++++++++++++++++
+ browser/extensions/moz.build          |   3 +-
+ 2 files changed, 348 insertions(+), 1 deletion(-)
+ create mode 100644 browser/extensions/ghostery/moz.build
+
+diff --git a/browser/extensions/ghostery/moz.build b/browser/extensions/ghostery/moz.build
+new file mode 100644
+index 0000000000..ffade40eff
+--- /dev/null
++++ b/browser/extensions/ghostery/moz.build
+@@ -0,0 +1,346 @@
++# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
++# vim: set filetype=python:
++# This Source Code Form is subject to the terms of the Mozilla Public
++# License, v. 2.0. If a copy of the MPL was not distributed with this
++# file, You can obtain one at http://mozilla.org/MPL/2.0/.
++
++DEFINES['MOZ_APP_VERSION'] = CONFIG['MOZ_APP_VERSION']
++DEFINES['MOZ_APP_MAXVERSION'] = CONFIG['MOZ_APP_MAXVERSION']
++
++id = 'firefox@ghostery.com'
++
++FINAL_TARGET_FILES.features['firefox@ghostery.com'] += [
++  'manifest.json',
++]
++
++FINAL_TARGET_FILES.features['firefox@ghostery.com']['databases'] += sorted([
++  'databases/bugs.json',
++  'databases/click2play.json',
++  'databases/compatibility.json',
++  'databases/surrogates.json',
++])
++
++FINAL_TARGET_FILES.features['firefox@ghostery.com']['app']['images'] += sorted([
++  'app/images/icon16.png',
++  'app/images/icon38.png'
++])
++
++files = '''app/images/drawer/x.svg
++app/images/panel/insights-ribbon.svg
++app/images/panel/caret-down.svg
++app/images/panel/spring-plus-logo.svg
++app/images/panel/icon-simple-mode.svg
++app/images/panel/search.svg
++app/images/panel/premium-sparkles-icon.svg
++app/images/panel/essential.svg
++app/images/panel/warning-slow.svg
++app/images/panel/upgrade-banner-plus.svg
++app/images/panel/kebab-menu.svg
++app/images/panel/plus-badge-icon.svg
++app/images/panel/smed.svg
++app/images/panel/allow.svg
++app/images/panel/stats-locked.svg
++app/images/panel/protected.svg
++app/images/panel/export.svg
++app/images/panel/unknown.svg
++app/images/panel/anonymized.svg
++app/images/panel/click-to-play.svg
++app/images/panel/comments.svg
++app/images/panel/checkbox-checked.svg
++app/images/panel/audio_video_player.svg
++app/images/panel/back_arrow_icon.png
++app/images/panel/site_analytics.svg
++app/images/panel/icon-information-tooltip-blue.svg
++app/images/panel/plus-badge-icon-expanded-view.svg
++app/images/panel/warning-insecure-faded.svg
++app/images/panel/adv.svg
++app/images/panel/warning-insecure-slow-faded.svg
++app/images/panel/customer_interaction.svg
++app/images/panel/midnight-beta-icon.svg
++app/images/panel/caret-up.svg
++app/images/panel/gear-icon.svg
++app/images/panel/import.svg
++app/images/panel/warning-compatibility-faded.svg
++app/images/panel/green-upgrade-banner-expanded-view.svg
++app/images/panel/caret-right.svg
++app/images/panel/plus.svg
++app/images/panel/purple-star.svg
++app/images/panel/info.svg
++app/images/panel/tracker-list-background.svg
++app/images/panel/loading.svg
++app/images/panel/midnight-logo.svg
++app/images/panel/warning-insecure-slow.svg
++app/images/panel/adsblocked.svg
++app/images/panel/line.svg
++app/images/panel/left-right-moon.svg
++app/images/panel/checkbox-disabled.svg
++app/images/panel/checkbox.svg
++app/images/panel/manage-subscription.svg
++app/images/panel/premium-badge-icon.svg
++app/images/panel/checked-circle-icon.svg
++app/images/panel/icon-information-tooltip.svg
++app/images/panel/left-left-moon.svg
++app/images/panel/pornvertising.svg
++app/images/panel/blocked.svg
++app/images/panel/eye.svg
++app/images/panel/icon-list-view.svg
++app/images/panel/ghostery-icon.svg
++app/images/panel/rewards-icon.svg
++app/images/panel/header-logo-icon.svg
++app/images/panel/subscribe-badge.svg
++app/images/panel/header-back-arrow.svg
++app/images/panel/warning-compatibility.svg
++app/images/panel/caret-left.svg
++app/images/panel/premium-badge-icon-expanded-view.svg
++app/images/panel/warning-insecure.svg
++app/images/panel/green-upgrade-banner.svg
++app/images/panel/icon-trust-restrict-x.svg
++app/images/panel/graph.svg
++app/images/panel/restrict.svg
++app/images/panel/midnight-check-icon.svg
++app/images/panel/warning-slow-faded.svg
++app/images/icon38_star.png
++app/images/licenses/logo-title-white.svg
++app/images/apps_pages/tracker.png
++app/images/icon48.png
++app/images/icon19_off.png
++app/images/rewards/ghosty-grey.svg
++app/images/rewards/ghosty-star.svg
++app/images/premium-sparkle.svg
++app/images/icon128.png
++app/images/icon19_star.png
++app/images/icon38_off.png
++app/images/icon19.png
++app/images/hub/home/recommended-banner.svg
++app/images/hub/home/check-icon.svg
++app/images/hub/home/ghosty-bubble-heart.svg
++app/images/hub/home/gold-ghostie-badge.svg
++app/images/hub/upgrade/arrow-down.svg
++app/images/hub/upgrade/ghostery-basic-card.svg
++app/images/hub/upgrade/x-icon.svg
++app/images/hub/upgrade/check.svg
++app/images/hub/upgrade/ghostery-premium-card.svg
++app/images/hub/upgrade/ghostery-plus-card.svg
++app/images/hub/tutorial/video-poster.png
++app/images/hub/tutorial/trustrestrict-detailed.png
++app/images/hub/tutorial/blocking-detailed-expanded.png
++app/images/hub/tutorial/tracker-list.png
++app/images/hub/tutorial/layout-simple.png
++app/images/hub/tutorial/antisuite-detailed.png
++app/images/hub/tutorial/blocking-detailed.png
++app/images/hub/tutorial/trustrestrict-simple.png
++app/images/hub/tutorial/antisuite-simple.png
++app/images/hub/tutorial/layout-detailed.png
++app/images/hub/products/app_store_badge_us.svg
++app/images/hub/products/product-mobile-browser.png
++app/images/hub/products/product-new-tab.png
++app/images/hub/products/google-play-badge.png
++app/images/hub/products/app_store_mac_badge_us.svg
++app/images/hub/products/product-ghostery-lite.png
++app/images/hub/rewards/background-stars-right.svg
++app/images/hub/rewards/background-stars-left.svg
++app/images/hub/rewards/ghostery-rewards-laptop.png
++app/images/hub/setup/ghosty-icon.svg
++app/images/hub/setup/block-all.svg
++app/images/hub/setup/block-selected.svg
++app/images/hub/setup/ghosty-human-web.svg
++app/images/hub/setup/ghosty-check-wrench.svg
++app/images/hub/setup/ghosty-block-all.svg
++app/images/hub/setup/ghosty-shield-stop-lightbulb.svg
++app/images/hub/setup/block-custom.svg
++app/images/hub/setup/block-recommended.svg
++app/images/hub/setup/block-none.svg
++app/images/hub/side-navigation/ghostery-logo.svg
++app/images/hub/side-navigation/ghostery-stacked-logo.svg
++app/images/hub/account/ghosty-account.svg
++app/images/hub/plus/feature-more.svg
++app/images/hub/plus/manifesto-background.svg
++app/images/hub/plus/feature-stats.svg
++app/images/hub/plus/plus-logo.svg
++app/images/hub/plus/feature-theme.png
++app/images/hub/plus/feature-support.svg
++app/images/panel-android/down.svg
++app/images/panel-android/up.svg
++app/images/panel-android/icon-information-blue.svg
++app/images/panel-android/back.svg
++app/images/panel-android/play.svg
++app/images/panel-android/icon-information-grey.svg
++app/images/panel-android/blocked.png
++app/images/panel-android/kebab-menu-black.svg
++app/images/panel-android/pause.svg
++app/images/panel-android/categories/essential.svg
++app/images/panel-android/categories/smed.svg
++app/images/panel-android/categories/comments.svg
++app/images/panel-android/categories/audio_video_player.svg
++app/images/panel-android/categories/site_analytics.svg
++app/images/panel-android/categories/adv.svg
++app/images/panel-android/categories/customer_interaction.svg
++app/images/panel-android/categories/pornvertising.svg
++app/templates/hub.html
++app/templates/licenses.html
++app/templates/click2play.html
++app/templates/panel.html
++app/templates/blocked_redirect.html
++app/templates/panel_android.html
++app/fonts/open-sans-latin-bold-700.woff2
++app/fonts/opensans-semibold-latin.woff2
++app/fonts/roboto-all-charsets.woff2
++app/fonts/opensans-semibold-latin-ext.woff2
++app/fonts/opensans-light-greek-ext.woff2
++app/fonts/opensans-light-latin.woff2
++app/fonts/opensans-normal-latin-ext.woff2
++app/fonts/opensans-normal-latin.woff2
++app/fonts/roboto-latin-bold-300.woff2
++app/fonts/opensans-normal-vietnamese.woff2
++app/fonts/opensans-normal-greek-ext.woff2
++app/fonts/opensans-light-latin-ext.woff2
++app/fonts/opensans-semibold-greek-ext.woff2
++app/fonts/roboto-condensed-latin-bold-700.woff2
++app/fonts/opensans-normal-cyrillic.woff2
++app/fonts/opensans-light-vietnamese.woff2
++app/fonts/roboto-latin-bold-900.woff2
++app/fonts/opensans-light-cyrillic.woff2
++app/fonts/roboto-latin-bold-500.woff2
++app/fonts/opensans-light-cyrillic-ext.woff2
++app/fonts/opensans-semibold-vietnamese.woff2
++app/fonts/opensans-semibold-cyrillic.woff2
++app/fonts/opensans-semibold-greek.woff2
++app/fonts/opensans-normal-greek.woff2
++app/fonts/opensans-normal-cyrillic-ext.woff2
++app/fonts/opensans-light-greek.woff2
++app/fonts/roboto-latin-bold-700.woff2
++app/fonts/opensans-semibold-cyrillic-ext.woff2
++LICENSE
++dist/account_pages.js
++dist/background.js
++dist/css/foundation_hub.css
++dist/css/hub.css
++dist/css/purplebox_styles.css
++dist/css/ghostery_dot_com_css.css
++dist/css/panel.css
++dist/css/licenses.css
++dist/css/panel_android.css
++dist/css/foundation.css
++dist/page_performance.js
++dist/licenses_react.js
++dist/content_script_bundle.js
++dist/hub_react.js
++dist/panel_android_react.js
++dist/blocked_redirect.js
++dist/ghostery_dot_com.js
++dist/panel_react.js
++dist/click_to_play.js
++dist/checkout_pages.js
++dist/notifications.js
++dist/purplebox.js
++dist/shared_comp_react.js
++_locales/pl/messages.json
++_locales/pt_BR/messages.json
++_locales/ja/messages.json
++_locales/it/messages.json
++_locales/zh_TW/messages.json
++_locales/ru/messages.json
++_locales/zh_CN/messages.json
++_locales/hu/messages.json
++_locales/nl/messages.json
++_locales/de/messages.json
++_locales/ko/messages.json
++_locales/fr/messages.json
++_locales/es/messages.json
++_locales/en/messages.json
++cliqz/core/EventUtils.js
++cliqz/core/setup-content.js
++cliqz/core/tracker_db_v2.json
++cliqz/core/content-script.bundle.js
++cliqz/core/logo-database.json
++cliqz/core/content-script.bundle.js.LICENSE.txt
++cliqz/myoffrz-helper/category-pattern.json
++cliqz/human-web/rusha.bundle.js.LICENSE.txt
++cliqz/human-web/humanweb.html
++cliqz/human-web/anonpatterns.json
++cliqz/human-web/patterns.json
++cliqz/human-web/rusha.bundle.js
++cliqz/adblocker/index.html
++cliqz/anti-phishing/images/white-warning.svg
++cliqz/anti-phishing/phishing-warning.html
++cliqz/hpnv2/worker.wasm.bundle.js.LICENSE.txt
++cliqz/hpnv2/worker.wasm.bundle.js
++cliqz/hpnv2/worker.asmjs.bundle.js.LICENSE.txt
++cliqz/hpnv2/worker.asmjs.bundle.js
++cliqz/offers-v2/offers_history.json
++cliqz/offers-v2/images/offers-cc-icon.svg
++cliqz/offers-v2/signals_data.json
++cliqz/offers-v2/environment.bundle.js
++cliqz/offers-v2/environment/index.html
++cliqz/offers-v2/environment/debug.html
++cliqz/offers-v2/environment.bundle.js.LICENSE.txt
++cliqz/offers-templates/offers-control-center.bundle.js.LICENSE.txt
++cliqz/offers-templates/control-center.html
++cliqz/offers-templates/offers-checkout.bundle.js.LICENSE.txt
++cliqz/offers-templates/images/triangle.svg
++cliqz/offers-templates/images/myoffrz-floating-button.svg
++cliqz/offers-templates/images/powered-by.svg
++cliqz/offers-templates/images/chip-logo.svg
++cliqz/offers-templates/images/onboarding-emoji.png
++cliqz/offers-templates/images/expired-grey.svg
++cliqz/offers-templates/images/expired-yellow.svg
++cliqz/offers-templates/images/feedback-face.svg
++cliqz/offers-templates/images/thank-you-emoji.png
++cliqz/offers-templates/images/myoffrz-tooltip-logo.svg
++cliqz/offers-templates/images/Belly75.gif
++cliqz/offers-templates/images/myoffrz-icon-logo.svg
++cliqz/offers-templates/images/BellyCongra.gif
++cliqz/offers-templates/images/close.svg
++cliqz/offers-templates/images/chip-icon-logo.svg
++cliqz/offers-templates/images/chip-floating-button.svg
++cliqz/offers-templates/images/offers-cc-icon.svg
++cliqz/offers-templates/images/ghosty-floating-button.svg
++cliqz/offers-templates/images/survey-emoji.png
++cliqz/offers-templates/images/close-offer.svg
++cliqz/offers-templates/images/ghosty-grey.svg
++cliqz/offers-templates/images/cliqz-tooltip-logo.svg
++cliqz/offers-templates/images/floating-button.svg
++cliqz/offers-templates/images/3dots-menu.svg
++cliqz/offers-templates/images/chip-tooltip-logo.svg
++cliqz/offers-templates/images/trash.svg
++cliqz/offers-templates/images/offers-cc-icon-white.svg
++cliqz/offers-templates/images/ghostery_O.png
++cliqz/offers-templates/images/ghosty-white-star.svg
++cliqz/offers-templates/images/spinner.svg
++cliqz/offers-templates/images/feedback-trash.png
++cliqz/offers-templates/images/chip-icon-logo-gray.svg
++cliqz/offers-templates/images/reason-emoji.png
++cliqz/offers-templates/images/ghostery-big-logo.svg
++cliqz/offers-templates/images/expired-red.svg
++cliqz/offers-templates/images/cliqz-big-logo.svg
++cliqz/offers-templates/images/cliqz-logo.svg
++cliqz/offers-templates/images/chip-big-logo.svg
++cliqz/offers-templates/images/Belly125.gif
++cliqz/offers-templates/images/ghostery-rewards-beta.svg
++cliqz/offers-templates/images/myoffrz-big-logo.svg
++cliqz/offers-templates/images/chip-icon-logo.png
++cliqz/offers-templates/reminder.html
++cliqz/offers-templates/offers-control-center-after.bundle.js.LICENSE.txt
++cliqz/offers-templates/styles/checkout.css
++cliqz/offers-templates/styles/widgets.css
++cliqz/offers-templates/styles/reminder.css
++cliqz/offers-templates/styles/control-center.css
++cliqz/offers-templates/checkout.html
++cliqz/offers-templates/offers-checkout.bundle.js
++cliqz/offers-templates/offers-control-center-after.bundle.js
++cliqz/offers-templates/offers-control-center.bundle.js
++cliqz/offers-templates/offers-reminder.bundle.js.LICENSE.txt
++cliqz/offers-templates/offers-reminder.bundle.js
++cliqz/antitracking/config.json
++cliqz/antitracking/prob.json
++cliqz/antitracking/bloom_filter.json
++cliqz/antitracking/bloom_config.json
++cliqz/vendor/react.js
++cliqz/vendor/react-dom.js'''
++
++for path in files.split('\n'):
++    root = FINAL_TARGET_FILES.features[id]
++    parts = path.split('/')
++    for folder in parts[:-1]:
++        root = root[folder]
++    root += [path]
+diff --git a/browser/extensions/moz.build b/browser/extensions/moz.build
+index 4c9fa789d1..ee2cfa1919 100644
+--- a/browser/extensions/moz.build
++++ b/browser/extensions/moz.build
+@@ -10,5 +10,6 @@ DIRS += [
+     'pdfjs',
+     'screenshots',
+     'webcompat',
+-    'report-site-issue'
++    'report-site-issue',
++    'ghostery'
+ ]
+-- 
+2.28.0
+


### PR DESCRIPTION
Integrates the ghostery extension bundled in the `browser/extensions` folder. Fixes #12 

Things to figure out:
 * How to integrate the fetching of the ghostery-extension into `fern`? Should `.workspace` also include the ghostery tag/url?
 * Auto-generation of the `moz.build` - this file has to specify all files in the extension. This should be automated when importing the extension (i.e. by fern?).