### PR TITLE
Enable MAR verification

### DIFF
--- a/build/configs/ghostery.mozconfig
+++ b/build/configs/ghostery.mozconfig
@@ -3,7 +3,6 @@ ac_add_options --with-app-name=Ghostery
 ac_add_options --enable-official-branding
 ac_add_options --with-branding=browser/branding/ghostery
 ac_add_options --enable-update-channel=release
-ac_add_options --disable-verify-mar
 
 export MOZ_APP_PROFILE=Ghostery
 export ACCEPTED_MAR_CHANNEL_IDS=firefox-ghostery-release


### PR DESCRIPTION
This PR should enable MAR verification. After merging, automated updates should stop working. Another PR will follow that replace public keys for MAR verification which should reenable the updates.