### PR TITLE
CD: copy mozconfig file before the build starts

### DIFF
--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -84,7 +84,7 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
             docker.build("ua-build-${name.toLowerCase()}", "-f build/${dockerFile} ./build")
         }
         
-        sh 'cp brands/ghostery/mozconfig builds/configs/'
+        sh 'cp brands/ghostery/mozconfig build/configs/'
         
         image.inside("--env MOZCONFIG=/builds/worker/configs/${mozconfig} --env MOZ_BUILD_DATE=${buildId} -v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
             stage('prepare mozilla-release') {

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -77,10 +77,10 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
             if (!fileExists('./build/MacOSX10.11.sdk.tar.bz2')) {
                 sh 'wget -O ./build/MacOSX10.11.sdk.tar.bz2 ftp://cliqznas.cliqz/cliqz-browser-build-artifacts/MacOSX10.11.sdk.tar.bz2'
             }
-            
+
             sh 'cp brands/ghostery/mozconfig build/configs/'
         }
-        
+
         image = stage('docker build base') {
             docker.build('ua-build-base', '-f build/Base.dockerfile ./build/ --build-arg user=`whoami` --build-arg UID=`id -u` --build-arg GID=`id -g`')
             docker.build("ua-build-${name.toLowerCase()}", "-f build/${dockerFile} ./build")

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -92,6 +92,7 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
                 }
                 sh 'rm -rf mozilla-release'
                 sh "./fern.js use"
+                sh 'cp brands/ghostery/mozconfig /build/workers/config'
                 sh "./fern.js reset"
                 sh './fern.js import-patches'
             }

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -92,7 +92,7 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
                 }
                 sh 'rm -rf mozilla-release'
                 sh "./fern.js use"
-                sh 'cp brands/ghostery/mozconfig /build/workers/configs/'
+                sh 'cp brands/ghostery/mozconfig /build/worker/configs/'
                 sh "./fern.js reset"
                 sh './fern.js import-patches'
             }

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -83,7 +83,9 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
             docker.build('ua-build-base', '-f build/Base.dockerfile ./build/ --build-arg user=`whoami` --build-arg UID=`id -u` --build-arg GID=`id -g`')
             docker.build("ua-build-${name.toLowerCase()}", "-f build/${dockerFile} ./build")
         }
-
+        
+        sh 'cp brands/ghostery/mozconfig builds/configs/'
+        
         image.inside("--env MOZCONFIG=/builds/worker/configs/${mozconfig} --env MOZ_BUILD_DATE=${buildId} -v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
             stage('prepare mozilla-release') {
                 sh 'npm ci'
@@ -92,7 +94,6 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
                 }
                 sh 'rm -rf mozilla-release'
                 sh "./fern.js use"
-                sh 'cp brands/ghostery/mozconfig /builds/worker/configs/'
                 sh "./fern.js reset"
                 sh './fern.js import-patches'
             }

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -92,7 +92,7 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
                 }
                 sh 'rm -rf mozilla-release'
                 sh "./fern.js use"
-                sh 'cp brands/ghostery/mozconfig /build/worker/configs/'
+                sh 'cp brands/ghostery/mozconfig /builds/worker/configs/'
                 sh "./fern.js reset"
                 sh './fern.js import-patches'
             }

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -92,7 +92,7 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
                 }
                 sh 'rm -rf mozilla-release'
                 sh "./fern.js use"
-                sh 'cp brands/ghostery/mozconfig /build/workers/config'
+                sh 'cp brands/ghostery/mozconfig /build/workers/configs/'
                 sh "./fern.js reset"
                 sh './fern.js import-patches'
             }

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -77,14 +77,14 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
             if (!fileExists('./build/MacOSX10.11.sdk.tar.bz2')) {
                 sh 'wget -O ./build/MacOSX10.11.sdk.tar.bz2 ftp://cliqznas.cliqz/cliqz-browser-build-artifacts/MacOSX10.11.sdk.tar.bz2'
             }
+            
+            sh 'cp brands/ghostery/mozconfig build/configs/'
         }
-
+        
         image = stage('docker build base') {
             docker.build('ua-build-base', '-f build/Base.dockerfile ./build/ --build-arg user=`whoami` --build-arg UID=`id -u` --build-arg GID=`id -g`')
             docker.build("ua-build-${name.toLowerCase()}", "-f build/${dockerFile} ./build")
         }
-        
-        sh 'cp brands/ghostery/mozconfig build/configs/'
         
         image.inside("--env MOZCONFIG=/builds/worker/configs/${mozconfig} --env MOZ_BUILD_DATE=${buildId} -v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
             stage('prepare mozilla-release') {

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -85,7 +85,7 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
             docker.build('ua-build-base', '-f build/Base.dockerfile ./build/ --build-arg user=`whoami` --build-arg UID=`id -u` --build-arg GID=`id -g`')
             docker.build("ua-build-${name.toLowerCase()}", "-f build/${dockerFile} ./build")
         }
-        
+
         image.inside("--env MOZCONFIG=/builds/worker/configs/${mozconfig} --env MOZ_BUILD_DATE=${buildId} -v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
             stage('prepare mozilla-release') {
                 sh 'npm ci'

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -77,7 +77,6 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
             if (!fileExists('./build/MacOSX10.11.sdk.tar.bz2')) {
                 sh 'wget -O ./build/MacOSX10.11.sdk.tar.bz2 ftp://cliqznas.cliqz/cliqz-browser-build-artifacts/MacOSX10.11.sdk.tar.bz2'
             }
-
             sh 'cp brands/ghostery/mozconfig build/configs/'
         }
 

--- a/fern/commands/use.js
+++ b/fern/commands/use.js
@@ -79,10 +79,6 @@ module.exports = (program) => {
 
         const tasks = new Listr([
           {
-            title: 'Copy mozconfig',
-            task: () => fs.copyFileSync('brands/ghostery/mozconfig', 'build/configs/mozconfig')
-          },
-          {
             title: `Setup Firefox ${workspace.firefox}`,
             task: async () => await firefox.use(workspace.firefox),
           },


### PR DESCRIPTION
This PR fixes the CI which now fails on first build.

Failure happens as `mozconfig` file that has to be added to docker context was only copied with `fern use` - which happens too late.