### PR TITLE
Disable data collection and use preferences section. Fixes #201

### DIFF
--- a/brands/ghostery/mozconfig
+++ b/brands/ghostery/mozconfig
@@ -3,6 +3,9 @@ ac_add_options --with-app-name=Ghostery
 ac_add_options --enable-official-branding
 ac_add_options --with-branding=browser/branding/ghostery
 ac_add_options --enable-update-channel=release
+ac_add_options --disable-verify-mar
+ac_add_options --disable-crashreporter
+ac_add_options MOZ_TELEMETRY_REPORTING=
 
 export MOZ_APP_PROFILE=Ghostery
 export ACCEPTED_MAR_CHANNEL_IDS=firefox-ghostery-release

--- a/patches/.index
+++ b/patches/.index
@@ -8,3 +8,4 @@
 0008-Remove-tracking-protection-panel-from-url-bar.patch
 0009-Hide-Protection-Dashboard-link-from-right-burger-men.patch
 0010-Remove-Tracking-Protection-Settings-from-preferences.patch
+0011-Force-healthreport-and-normandy-off-at-configure-tim.patch

--- a/patches/0011-Force-healthreport-and-normandy-off-at-configure-tim.patch
+++ b/patches/0011-Force-healthreport-and-normandy-off-at-configure-tim.patch
@@ -1,0 +1,29 @@
+From: Jenkins <jenkins@magrathea>
+Date: Wed, 16 Sep 2020 17:33:07 +0200
+Subject: Force healthreport and normandy off at configure-time
+
+---
+ browser/moz.configure | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/browser/moz.configure b/browser/moz.configure
+index a251050feb..5aada7532e 100644
+--- a/browser/moz.configure
++++ b/browser/moz.configure
+@@ -5,11 +5,11 @@
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ 
+ imply_option('MOZ_PLACES', True)
+-imply_option('MOZ_SERVICES_HEALTHREPORT', True)
++imply_option('MOZ_SERVICES_HEALTHREPORT', False)
+ imply_option('MOZ_SERVICES_SYNC', True)
+ imply_option('MOZ_DEDICATED_PROFILES', True)
+ imply_option('MOZ_BLOCK_PROFILE_DOWNGRADE', True)
+-imply_option('MOZ_NORMANDY', True)
++imply_option('MOZ_NORMANDY', False)
+ 
+ with only_when(target_is_linux & compile_environment):
+     option(env='MOZ_NO_PIE_COMPAT',
+-- 
+2.25.1
+


### PR DESCRIPTION
#201 Remove 'Data Collection and Use' from preferences - Done by totally disabling all telemetry (healthreport, normandy, crash reporter and normal telemetry) at compile time. This unsets the `MOZ_DATA_REPORTING` flag, which means that the [preference section is not included](https://searchfox.org/mozilla-central/source/browser/components/preferences/privacy.inc.xhtml#837).