### PR TITLE
Remove crashreporter from mac signing

### DIFF
--- a/ci/sign_mac.sh
+++ b/ci/sign_mac.sh
@@ -29,11 +29,7 @@ do
   codesign --force -o runtime --verbose --sign "$IDENTITY" \
   "${BUNDLE}/Contents/MacOS/XUL" \
   "${BUNDLE}/Contents/MacOS/pingsender" \
-  "${BUNDLE}/Contents/MacOS/minidump-analyzer" \
   "${BUNDLE}"/Contents/MacOS/*.dylib
-
-  codesign --force -o runtime --verbose --sign "$IDENTITY" --deep \
-  "${BUNDLE}"/Contents/MacOS/crashreporter.app
 
   codesign --force -o runtime --verbose --sign "$IDENTITY" --deep \
   "${BUNDLE}"/Contents/MacOS/updater.app


### PR DESCRIPTION
The crashreporter app is no longer included in the app bundle since this was disabled in the build in #217