### PR TITLE
Fern config - helps to manage mozconfig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ logs
 .DS_Store
 build/configs/mozconfig
 /mozconfig
+/local.mozconfig

--- a/build/Linux.dockerfile
+++ b/build/Linux.dockerfile
@@ -48,6 +48,4 @@ ENV MOZ_FETCHES_DIR=/builds/worker/fetches/ \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en
 
-COPY configs /builds/worker/configs
-
 WORKDIR $WORKSPACE

--- a/build/MacOSX.dockerfile
+++ b/build/MacOSX.dockerfile
@@ -87,6 +87,4 @@ ENV MOZ_FETCHES_DIR=/builds/worker/fetches/ \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en
 
-COPY configs /builds/worker/configs
-
 WORKDIR $WORKSPACE

--- a/build/Windows.dockerfile
+++ b/build/Windows.dockerfile
@@ -92,6 +92,4 @@ ENV MOZ_FETCHES_DIR=/builds/worker/fetches/ \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en
 
-COPY configs /builds/worker/configs
-
 WORKDIR $WORKSPACE

--- a/build/configs/linux.mozconfig
+++ b/build/configs/linux.mozconfig
@@ -38,5 +38,3 @@ export MOZ_PACKAGE_JSSHELL=1
 
 # disable tests for this build
 ac_add_options --disable-tests
-
-. /builds/worker/configs/mozconfig

--- a/build/configs/macosx.mozconfig
+++ b/build/configs/macosx.mozconfig
@@ -68,5 +68,3 @@ unset MOZ_STDCXX_COMPAT
 
 # disable tests for this build
 ac_add_options --disable-tests
-
-. /builds/worker/configs/mozconfig

--- a/build/configs/win64.mozconfig
+++ b/build/configs/win64.mozconfig
@@ -93,5 +93,3 @@ export ENABLE_CLANG_PLUGIN=1
 
 # disable tests for this build
 ac_add_options --disable-tests
-
-. /builds/worker/configs/mozconfig

--- a/ci.multibranch.Jenkinsfile
+++ b/ci.multibranch.Jenkinsfile
@@ -29,7 +29,7 @@ if (params.Linux64) {
 
     buildmatrix[name] = {
         node('docker && !magrathea') {
-            helpers.build(name, 'Linux.dockerfile', 'linux.mozconfig', objDir, params, buildId)()
+            helpers.build(name, 'Linux.dockerfile', 'linux', objDir, params, buildId)()
 
             archiveArtifacts artifacts: "mozilla-release/$objDir/dist/update/*.mar"
             archiveArtifacts artifacts: "mozilla-release/${artifactGlob}"
@@ -56,7 +56,7 @@ if (params.Windows64) {
     buildmatrix[name] = {
         // we have to run windows builds on magrathea because that is where the vssdk mount is.
         node('docker && magrathea') {
-            helpers.build(name, 'Windows.dockerfile', 'win64.mozconfig', objDir, params, buildId)()
+            helpers.build(name, 'Windows.dockerfile', 'win64', objDir, params, buildId)()
 
             archiveArtifacts artifacts: "mozilla-release/$objDir/dist/update/*.mar"
             archiveArtifacts artifacts: "mozilla-release/${artifactGlob}"
@@ -84,7 +84,7 @@ if (params.MacOSX64) {
     def artifactGlob = "$objDir/dist/Ghostery-*"
     buildmatrix[name] = {
         node('docker && !magrathea') {
-            helpers.build(name, 'MacOSX.dockerfile', 'macosx.mozconfig', objDir, params, buildId)()
+            helpers.build(name, 'MacOSX.dockerfile', 'macosx', objDir, params, buildId)()
 
             archiveArtifacts artifacts: "mozilla-release/$objDir/dist/update/*.mar"
             archiveArtifacts artifacts: "mozilla-release/${artifactGlob}"

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -84,7 +84,7 @@ def build(name, dockerFile, targetPlatform, objDir, params, buildId) {
             docker.build("ua-build-${name.toLowerCase()}", "-f build/${dockerFile} ./build")
         }
 
-        image.inside("--env MOZCONFIG=`pwd`/mozconfig --env MOZ_BUILD_DATE=${buildId} -v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
+        image.inside("--env MOZCONFIG=${env.WORKSPACE}/mozconfig --env MOZ_BUILD_DATE=${buildId} -v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
             stage('prepare mozilla-release') {
                 sh 'npm ci'
                 if (params.Reset) {

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -64,7 +64,7 @@ def withVagrant(String vagrantFilePath, String jenkinsFolderPath, Integer cpu, I
     }
 }
 
-def build(name, dockerFile, mozconfig, objDir, params, buildId) {
+def build(name, dockerFile, targetPlatform, objDir, params, buildId) {
     return {
         stage('checkout') {
             checkout scm
@@ -77,7 +77,6 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
             if (!fileExists('./build/MacOSX10.11.sdk.tar.bz2')) {
                 sh 'wget -O ./build/MacOSX10.11.sdk.tar.bz2 ftp://cliqznas.cliqz/cliqz-browser-build-artifacts/MacOSX10.11.sdk.tar.bz2'
             }
-            sh 'cp brands/ghostery/mozconfig build/configs/'
         }
 
         image = stage('docker build base') {
@@ -85,7 +84,7 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
             docker.build("ua-build-${name.toLowerCase()}", "-f build/${dockerFile} ./build")
         }
 
-        image.inside("--env MOZCONFIG=/builds/worker/configs/${mozconfig} --env MOZ_BUILD_DATE=${buildId} -v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
+        image.inside("--env MOZCONFIG=`pwd`/mozconfig --env MOZ_BUILD_DATE=${buildId} -v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
             stage('prepare mozilla-release') {
                 sh 'npm ci'
                 if (params.Reset) {
@@ -93,6 +92,7 @@ def build(name, dockerFile, mozconfig, objDir, params, buildId) {
                 }
                 sh 'rm -rf mozilla-release'
                 sh "./fern.js use"
+                sh "./fern.js config --print --force --platform ${targetPlatform} --brand ghostery"
                 sh "./fern.js reset"
                 sh './fern.js import-patches'
             }

--- a/fern.js
+++ b/fern.js
@@ -8,6 +8,7 @@ const colors = require('colors');
 // register sub-commands
 require('./fern/commands/use')(program);
 require('./fern/commands/reset')(program);
+require('./fern/commands/config')(program);
 require('./fern/commands/generate')(program);
 require('./fern/commands/build')(program);
 require('./fern/commands/export-patches')(program);

--- a/fern/commands/config.js
+++ b/fern/commands/config.js
@@ -1,0 +1,84 @@
+const Listr = require("listr");
+const process = require("process");
+const fs = require("fs");
+const path = require("path");
+
+const MOZCONFIG_PATH = "mozconfig";
+
+module.exports = (program) => {
+  program
+    .command("config")
+    .description("Creates a mozconfig file based on brand and platform")
+    .option(
+      "-b, --brand <BRAND>",
+      "Specify which brand to use"
+    )
+    .option(
+      "-p, --platform <platform>",
+      "Specify which platform to use"
+    )
+    .option(
+      "-f, --force",
+      "Replace current mozconfig if exists"
+    )
+    .option(
+      "-l, --local",
+      "Choose if local.mozconfig should be used"
+    )
+    .option(
+      "--print",
+      "Print mozconfig to screen"
+    )
+    .action(
+      async ({ force, platform, brand, local, print }) => {
+        const tasks = new Listr([
+          {
+            title: "Generate mozconfig",
+            task: () => {
+              if (fs.existsSync(MOZCONFIG_PATH)) {
+                if (!force) {
+                  throw new Error("mozconfig already exist")
+                }
+              }
+              let brandMozConfig = "";
+              if (brand) {
+                brandMozConfig = fs.readFileSync(path.join("brands", brand, "mozconfig"));
+              }
+
+              let platformMozConfig = "";
+              if (platform) {
+                platformMozConfig = fs.readFileSync(path.join("build", "configs", `${platform}.mozconfig`));
+              }
+
+              let localMozconfig = "";
+              if (local) {
+                localMozconfig = fs.readFileSync("local.mozconfig");
+              }
+
+
+              const mozConfig = [
+                platformMozConfig.toString().trim(),
+                brandMozConfig.toString().trim(),
+                localMozconfig.toString().trim(),
+              ].join("\n");
+
+              if (print) {
+                console.log("fern: Generated MOZCONFIG START\n");
+                console.log(mozConfig);
+                console.log("\nfern: Generated MOZCONFIG END")
+              }
+
+              fs.writeFileSync(MOZCONFIG_PATH, mozConfig);
+            },
+          },
+        ]);
+
+        try {
+          await tasks.run();
+        } catch (ex) {
+          /* Handled by `tasks` */
+          process.exit(1);
+        }
+      }
+    );
+};

--- a/fern/commands/config.js
+++ b/fern/commands/config.js
@@ -15,7 +15,7 @@ module.exports = (program) => {
     )
     .option(
       "-p, --platform <platform>",
-      "Specify which platform to use"
+      "Specify which platform to use (e.g. win64, linux, macosx)"
     )
     .option(
       "-f, --force",


### PR DESCRIPTION
Fern config aims to support developers and CI in managing mozconfig files. 

It assumes that all builds will be configured with `MOZCONFIG=/<path_to_user-agent-destkop>/mozconfig`. 

Options allow to specify: *brand*, *platform* and optional *local* config. 

Local config is meant to be used in development as it allow to pass custom options and test them agains different brands / platforms without manual copy pasting.  