### PR TITLE
Fix about page wordmark.

### DIFF
--- a/brands/ghostery/branding/content/aboutDialog.css
+++ b/brands/ghostery/branding/content/aboutDialog.css
@@ -12,7 +12,7 @@
 }
 
 #leftBox {
-  background-image: url("chrome://branding/content/about-logo.png");
+  background-image: url("chrome://branding/content/firefox-wordmark.png");
   background-repeat: no-repeat;
   background-size: 192px auto;
   background-position: center 20%;


### PR DESCRIPTION
Part of #58. Replaces 'Nightly' wordmark, with a Ghostery logo.