### PR TITLE
Spoof UA on addons.mozilla.org so that addons can be installed

### DIFF
--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -120,3 +120,6 @@ pref("general.useragent.compatMode.firefox", true);
 // Recommend extensions/features as you browse
 pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features", false);
 pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons", false);
+
+// Remove addons.mozilla.org from set of domains that extensions cannot access
+pref("extensions.webextensions.restrictedDomains", "accounts-static.cdn.mozilla.net,accounts.firefox.com,addons.cdn.mozilla.net,api.accounts.firefox.com,content.cdn.mozilla.net,discovery.addons.mozilla.org,install.mozilla.org,oauth.accounts.firefox.com,profile.accounts.firefox.com,support.mozilla.org,sync.services.mozilla.com")

--- a/patches/.index
+++ b/patches/.index
@@ -10,3 +10,4 @@
 0010-Remove-Tracking-Protection-Settings-from-preferences.patch
 0011-Force-healthreport-and-normandy-off-at-configure-tim.patch
 0012-Hide-Recommend-as-you-browser-preferences.patch
+0013-Override-UA-for-addons.mozilla.org.patch

--- a/patches/0013-Override-UA-for-addons.mozilla.org.patch
+++ b/patches/0013-Override-UA-for-addons.mozilla.org.patch
@@ -1,0 +1,53 @@
+From: Sam Macbeth <sam@cliqz.com>
+Date: Fri, 18 Sep 2020 12:09:36 +0200
+Subject: Override UA for addons.mozilla.org
+
+---
+ browser/extensions/webcompat/data/ua_overrides.js   | 13 +++++++++++++
+ .../components/extensions/WebExtensionPolicy.cpp    |  6 +++---
+ 2 files changed, 16 insertions(+), 3 deletions(-)
+
+diff --git a/browser/extensions/webcompat/data/ua_overrides.js b/browser/extensions/webcompat/data/ua_overrides.js
+index 86f02a5237..ac525ffdc6 100644
+--- a/browser/extensions/webcompat/data/ua_overrides.js
++++ b/browser/extensions/webcompat/data/ua_overrides.js
+@@ -34,6 +34,19 @@ const AVAILABLE_UA_OVERRIDES = [
+       },
+     },
+   },
++  {
++    /* UA override for addons.mozilla.org so they think we're vanilla Firefox */
++    id: "amo-override",
++    platform: "all",
++    domain: "addons.mozilla.org",
++    bug: "0000001",
++    config: {
++      matches: ["*://addons.mozilla.org/*"],
++      uaTransformer: originalUA => {
++        return originalUA.substring(0, originalUA.indexOf('Ghostery') - 1);
++      },
++    },
++  },
+   {
+     /*
+      * Bug 1577519 - att.tv - Create a UA override for att.tv for playback on desktop
+diff --git a/toolkit/components/extensions/WebExtensionPolicy.cpp b/toolkit/components/extensions/WebExtensionPolicy.cpp
+index 48a8fb1a1c..c154cb5e87 100644
+--- a/toolkit/components/extensions/WebExtensionPolicy.cpp
++++ b/toolkit/components/extensions/WebExtensionPolicy.cpp
+@@ -432,9 +432,9 @@ bool WebExtensionPolicy::IsRestrictedURI(const URLInfo& aURI) {
+     return true;
+   }
+ 
+-  if (AddonManagerWebAPI::IsValidSite(aURI.URI())) {
+-    return true;
+-  }
++  // if (AddonManagerWebAPI::IsValidSite(aURI.URI())) {
++  //   return true;
++  // }
+ 
+   return false;
+ }
+-- 
+2.25.1
+


### PR DESCRIPTION
Unfortunately to do this via an extension we have to disable protection of `addons.mozilla.org`, meaning that 3rd party extensions could potentially exploit that to tamper with the addons site. I'm not sure how critical an issue this could be.