### PR TITLE
Move Ghostery icon into UrlBar

### DIFF
--- a/patches/.index
+++ b/patches/.index
@@ -25,3 +25,4 @@
 0025-Rename-Firefox-Home-to-Brand-Home.patch
 0026-Update-devtools-branding.patch
 0027-Ghostery-theme.patch
+0028-Move-Ghostery-icon-to-UrlBar.patch

--- a/patches/0028-Move-Ghostery-icon-to-UrlBar.patch
+++ b/patches/0028-Move-Ghostery-icon-to-UrlBar.patch
@@ -1,0 +1,28 @@
+From: Krzysztof Jan Modras <chrmod@chrmod.net>
+Date: Wed, 30 Sep 2020 12:22:19 +0200
+Subject: Move Ghostery icon to UrlBar
+
+---
+ browser/components/customizableui/CustomizableUI.jsm | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/browser/components/customizableui/CustomizableUI.jsm b/browser/components/customizableui/CustomizableUI.jsm
+index 517273b89c..8ee7598c52 100644
+--- a/browser/components/customizableui/CustomizableUI.jsm
++++ b/browser/components/customizableui/CustomizableUI.jsm
+@@ -1440,6 +1440,12 @@ var CustomizableUIInternal = {
+       this.ensureButtonContextMenu(widgetNode, aAreaNode);
+     }
+ 
++    if (widgetNode.getAttribute("data-extensionid") === "firefox@ghostery.com") {
++      const container = window.document.getElementById("urlbar-input-container");
++      container.insertAdjacentElement('afterbegin', widgetNode);
++      return;
++    }
++
+     let [insertionContainer, nextNode] = this.findInsertionPoints(
+       widgetNode,
+       aAreaNode
+-- 
+2.28.0
+


### PR DESCRIPTION
 fix #134

<img width="796" alt="Screenshot 2020-09-30 at 12 25 15" src="https://user-images.githubusercontent.com/1228153/94674116-00a76180-0318-11eb-83ad-1780110c2fb6.png">
