### PR TITLE
Update Ghostery-dmg.json

### DIFF
--- a/ci/Ghostery-dmg.json
+++ b/ci/Ghostery-dmg.json
@@ -5,12 +5,12 @@
   "icon-size": 80,
   "window": {
     "size": {
-        "width": 528,
-        "height": 360
+        "width": 575,
+        "height": 400
     }
   },
   "contents": [
-    { "x": 418, "y": 180, "type": "link", "path": "/Applications" },
-    { "x": 110, "y": 180, "type": "file", "path": "pkg/Ghostery Browser.app" }
+    { "x": 429, "y": 210, "type": "link", "path": "/Applications" },
+    { "x": 143, "y": 210, "type": "file", "path": "pkg/Ghostery Browser.app" }
   ]
 }

--- a/ci/Ghostery-dmg.json
+++ b/ci/Ghostery-dmg.json
@@ -3,6 +3,12 @@
   "background": "../brands/ghostery/branding/background.png",
   "icon": "../brands/ghostery/branding/disk.icns",
   "icon-size": 80,
+  "window": {
+    "size": {
+        "width": 528,
+        "height": 360
+    }
+  },
   "contents": [
     { "x": 418, "y": 180, "type": "link", "path": "/Applications" },
     { "x": 110, "y": 180, "type": "file", "path": "pkg/Ghostery Browser.app" }


### PR DESCRIPTION
Fixes DMG window size. Fixes #270.

Results in the following default dmg window:
