### PR TITLE
Fix missing ghostery search

### DIFF
--- a/patches/0021-Manual-override-of-search-engine-list.patch
+++ b/patches/0021-Manual-override-of-search-engine-list.patch
@@ -107,7 +107,7 @@ index 5a6992e0c9..5abcf6f003 100644
 +        },
 +      }],
 +      "webExtension": {
-+        "id": "ghostery@search.mozilla.org"
++        "id": "search@ghostery.com"
 +      }
 +    }, {
 +      "appliesTo": [{


### PR DESCRIPTION
Extension ID was changes and as the list of search engines is hardcoded the ghosterysearch.com was not shown.