### PR TITLE
Default theme update

### DIFF
--- a/patches/0024-Ghostery-theme.patch
+++ b/patches/0024-Ghostery-theme.patch
@@ -6,12 +6,13 @@ Subject: Ghostery theme
  toolkit/modules/LightweightThemeConsumer.jsm  |  2 +-
  .../background-gradient-dark.svg              |  1 +
  .../default-theme/background-gradient.svg     |  1 +
- .../extensions/default-theme/manifest.json    | 41 +++++++++----------
+ .../extensions/default-theme/manifest.json    | 43 +++++++++----------
+ .../extensions/internal/XPIProvider.jsm       |  2 +-
  toolkit/mozapps/extensions/jar.mn             |  2 +
  toolkit/themes/linux/global/toolbarbutton.css |  2 +-
  toolkit/themes/osx/global/toolbarbutton.css   |  2 +-
  .../themes/windows/global/toolbarbutton.css   |  2 +-
- 8 files changed, 28 insertions(+), 25 deletions(-)
+ 9 files changed, 30 insertions(+), 27 deletions(-)
  create mode 100644 toolkit/mozapps/extensions/default-theme/background-gradient-dark.svg
  create mode 100644 toolkit/mozapps/extensions/default-theme/background-gradient.svg
 
@@ -55,10 +56,11 @@ index 05d6e0e19a..9cc863bd5d 100644
 -  "name": "Default",
 -  "description": "A theme with the operating system color scheme.",
 -  "author": "Mozilla",
+-  "version": "1.1",
 +  "name": "Ghostery Browser Theme",
 +  "description": "",
 +  "author": "Ghostery",
-   "version": "1.1",
++  "version": "1.2",
  
    "icons": {"32": "icon.svg"},
  
@@ -105,6 +107,19 @@ index 05d6e0e19a..9cc863bd5d 100644
      }
    }
  }
+diff --git a/toolkit/mozapps/extensions/internal/XPIProvider.jsm b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+index 7b4e3b4f11..5e229ceeef 100644
+--- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
++++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+@@ -2460,7 +2460,7 @@ var XPIProvider = {
+ 
+       this.maybeInstallBuiltinAddon(
+         "default-theme@mozilla.org",
+-        "1.1",
++        "1.2",
+         "resource://default-theme/"
+       );
+ 
 diff --git a/toolkit/mozapps/extensions/jar.mn b/toolkit/mozapps/extensions/jar.mn
 index a203524e23..1b924aa053 100644
 --- a/toolkit/mozapps/extensions/jar.mn

--- a/patches/0024-Ghostery-theme.patch
+++ b/patches/0024-Ghostery-theme.patch
@@ -6,13 +6,13 @@ Subject: Ghostery theme
  toolkit/modules/LightweightThemeConsumer.jsm  |  2 +-
  .../background-gradient-dark.svg              |  1 +
  .../default-theme/background-gradient.svg     |  1 +
- .../extensions/default-theme/manifest.json    | 43 +++++++++----------
+ .../extensions/default-theme/manifest.json    | 45 ++++++++++---------
  .../extensions/internal/XPIProvider.jsm       |  2 +-
  toolkit/mozapps/extensions/jar.mn             |  2 +
  toolkit/themes/linux/global/toolbarbutton.css |  2 +-
  toolkit/themes/osx/global/toolbarbutton.css   |  2 +-
  .../themes/windows/global/toolbarbutton.css   |  2 +-
- 9 files changed, 30 insertions(+), 27 deletions(-)
+ 9 files changed, 32 insertions(+), 27 deletions(-)
  create mode 100644 toolkit/mozapps/extensions/default-theme/background-gradient-dark.svg
  create mode 100644 toolkit/mozapps/extensions/default-theme/background-gradient.svg
 
@@ -46,10 +46,10 @@ index 0000000000..850918c938
 +<svg height="200" viewBox="0 0 3000 200" width="3000" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><linearGradient id="a" x1="0%" x2="100%" y1="49.777778%" y2="50.187103%"><stop offset="0" stop-color="#720174"/><stop offset="1" stop-color="#00aef0"/></linearGradient><path d="m0 0h3000v200h-3000z" fill="url(#a)"/></svg>
 \ No newline at end of file
 diff --git a/toolkit/mozapps/extensions/default-theme/manifest.json b/toolkit/mozapps/extensions/default-theme/manifest.json
-index 05d6e0e19a..9cc863bd5d 100644
+index 05d6e0e19a..aaf5e35c09 100644
 --- a/toolkit/mozapps/extensions/default-theme/manifest.json
 +++ b/toolkit/mozapps/extensions/default-theme/manifest.json
-@@ -7,36 +7,35 @@
+@@ -7,36 +7,37 @@
      }
    },
  
@@ -72,7 +72,9 @@ index 05d6e0e19a..9cc863bd5d 100644
 +      "frame": "rgba(114, 1, 116, 1)",
 +      "tab_background_text": "rgba(255, 255, 255, 1)",
 +      "toolbar": "rgba(0, 0, 0, 0.5)",
-+      "toolbar_field_text": "rgba(0, 0, 0, 1)"
++      "toolbar_field_text": "rgba(0, 0, 0, 1)",
++      "toolbar_field_highlight": "#00aef0",
++      "popup_highlight": "#00aef0"
 +    }
    },
  

--- a/patches/0024-Ghostery-theme.patch
+++ b/patches/0024-Ghostery-theme.patch
@@ -73,7 +73,7 @@ index 05d6e0e19a..aaf5e35c09 100644
 +      "tab_background_text": "rgba(255, 255, 255, 1)",
 +      "toolbar": "rgba(0, 0, 0, 0.5)",
 +      "toolbar_field_text": "rgba(0, 0, 0, 1)",
-+      "toolbar_field_highlight": "#00aef0",
++      "toolbar_field_highlight": "#0063E1",
 +      "popup_highlight": "#00aef0"
 +    }
    },


### PR DESCRIPTION
On top of Firefox 82 themes now update correctly if both manifest and installation call specify correct versions.

fix #266
fix #277