### PR TITLE
Restore Ghostery in UA string.

### DIFF
--- a/brands/ghostery/branding/configure.sh
+++ b/brands/ghostery/branding/configure.sh
@@ -6,3 +6,4 @@ MOZ_APP_VENDOR=Ghostery
 MOZ_APP_BASENAME=Ghostery
 MOZ_APP_DISPLAYNAME="Ghostery Browser"
 MOZ_MACBUNDLE_ID=com.ghostery.browser
+MOZ_DISTRIBUTION_ID=com.ghostery

--- a/brands/ghostery/mozconfig
+++ b/brands/ghostery/mozconfig
@@ -1,5 +1,6 @@
 
 ac_add_options --with-app-name=Ghostery
+ac_add_options --with-app-basename=Ghostery
 ac_add_options --enable-official-branding
 ac_add_options --with-branding=browser/branding/ghostery
 ac_add_options --enable-update-channel=release


### PR DESCRIPTION
Fixes a regression since #290 that `MOZ_APP_BASENAME` was set to `Firefox`.