### PR TITLE
Clean up work dir on windows signer

### DIFF
--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -185,6 +185,8 @@ def windows_signing(name, objDir, artifactGlob) {
                 node(nodeId) {
                     stage("Checkout") {
                         checkout scm
+                        // clean old build artifacts in work dir
+                        sh 'rm -rf mozilla-release'
                     }
                     stage('Prepare') {
                         unstash name


### PR DESCRIPTION
Since we bumped version number we are still publishing a 2020.9 windows build to releases. This is because the workdir on the windows signer is not being clean up, so old build artifacts will be resigned and re-archived.