### PR TITLE
Update "Firefox" strings in windows manifest.

### DIFF
--- a/fern/patches/hardcoded-strings.js
+++ b/fern/patches/hardcoded-strings.js
@@ -3,7 +3,8 @@ const fsExtra = require("fs-extra");
 const { getRoot } = require("../core/workspace.js");
 
 const files = [
-  ["browser", "locales", "en-US", "chrome", "overrides", "appstrings.properties"]
+  ["browser", "locales", "en-US", "chrome", "overrides", "appstrings.properties"],
+  ["browser", "app", "firefox.exe.manifest"]
 ]
 
 module.exports = () => ({


### PR DESCRIPTION
Just to make sure the Firefox strings are not surfaced in the Ghostery.exe metadata.