### PR TITLE
Disable dropdown suggestion of topsites and search engines. Fixes #250

### DIFF
--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -149,3 +149,6 @@ pref("signon.management.page.breach-alerts.enabled", false);
 
 // Disable Firefox VPN promo
 pref("browser.privatebrowsing.vpnpromourl", "");
+
+// Disable dropdown suggestions with empty query
+pref("browser.urlbar.suggest.topsites", false);


### PR DESCRIPTION
Disables the dropdown when there is an empty query. On a new profile this was suggesting 'Search with Google'.