### PR TITLE
Revert "Switch to our own detect portal"

### DIFF
--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -152,6 +152,3 @@ pref("browser.privatebrowsing.vpnpromourl", "");
 
 // Disable dropdown suggestions with empty query
 pref("browser.urlbar.suggest.topsites", false);
-
-// Captive portal detection: use our endpoint instead of firefox.com
-pref("captivedetect.canonicalURL", "http://get.ghosterybrowser.com/detect/success.txt");


### PR DESCRIPTION
Reverts ghostery/user-agent-desktop#326

This is causing some issues as the get.ghosterybrowser.com endpoint auto-upgrades http connections and caches this upgrade, so the detect mechanism isn't working properly. We will have to deploy a new endpoint for this, or continue to use firefox's detect portal.