### PR TITLE
Bump Firefox to 82.0.3

### DIFF
--- a/.workspace
+++ b/.workspace
@@ -3,6 +3,6 @@
     "ghostery": "https://ghostery-deployments.s3.amazonaws.com/ghostery-extension/8.5.4.5bf5c45f/ghostery-firefox-v8.5.4.zip",
     "ghostery-search": "https://github.com/ghostery/ghostery-search-extension/releases/download/v0.1.13/ghostery_search-0.1.13.zip"
   },
-  "firefox": "82.0.2",
+  "firefox": "82.0.3",
   "app": "2020.10.1"
 }


### PR DESCRIPTION
Security fix from Mozilla: https://www.mozilla.org/en-US/firefox/82.0.3/releasenotes/