### PR TITLE
Keep IPFS address of browser resources in workspace

### DIFF
--- a/.workspace
+++ b/.workspace
@@ -4,5 +4,6 @@
     "ghostery-search": "https://github.com/ghostery/ghostery-search-extension/releases/download/v0.1.13/ghostery_search-0.1.13.zip"
   },
   "firefox": "82.0.3",
-  "app": "2020.10.1"
+  "app": "2020.10.1",
+  "ipfsAddr": "/ipfs/QmUajsHzRDKSTzVhz8WtPnMxqv5dqADBrxHSbbp1RathRZ"
 }

--- a/fern/commands/use.js
+++ b/fern/commands/use.js
@@ -62,7 +62,7 @@ module.exports = (program) => {
         const tasks = new Listr([
           {
             title: `Setup Firefox ${workspace.firefox}`,
-            task: async () => await firefox.use(workspace.firefox, ipfsGateway),
+            task: async () => await firefox.use(workspace.firefox, ipfsGateway, workspace.ipfsAddr),
           },
           {
             title: `Setup Addons`,

--- a/fern/core/firefox.js
+++ b/fern/core/firefox.js
@@ -13,15 +13,14 @@ const { getRoot } = require("./workspace.js");
 const { getCacheDir } = require("./caching.js");
 const { fileExists, folderExists, symlinkExists } = require("./utils.js");
 
-async function use(version, ipfsGateway) {
+async function use(version, ipfsGateway, ipfsAddr) {
   const root = await getRoot();
   const cache = await getCacheDir("firefox", `${version}`);
   const folder = path.join(cache, `firefox-${version}`);
   const archive = path.join(cache, `firefox-${version}.source.tar.xz`);
   const git = path.join(folder, ".git");
-  const baseUrl = ipfsGateway ? `${ipfsGateway}/ipns/k2k4r8jy3h2kku2sungmzbrp2zpj3yf2js0w98bwbbyiqt2qzomkvyli` : "https://archive.mozilla.org/pub";
+  const baseUrl = ipfsGateway ? `${ipfsGateway}${ipfsAddr}` : "https://archive.mozilla.org/pub";
   const url = `${baseUrl}/firefox/releases/${version}/source/firefox-${version}.source.tar.xz`;
-
   return new Listr([
     {
       title: "Download",


### PR DESCRIPTION
This adds the IPFS address of a folder of browser resources in the workspace, which serves the following purposes:
 * Enables downloading of firefox source via IPFS on CI. This replaces the IPNS link we were using before, as this was slow to update, and is also not immutable like the IPFS address. Therefore using IPFS address is better for keeping older builds reproducable.
 * The IPFS folder also contains toolchains needed for building, so anyone wanting to build the project can quickly reference this address to get the full toolchain needed to build the browser.