### PR TITLE
Windows aarch64 Build

### DIFF
--- a/build/WindowsARM.dockerfile
+++ b/build/WindowsARM.dockerfile
@@ -1,0 +1,99 @@
+FROM ua-build-base
+
+ARG IPFS_GATEWAY=https://cloudflare-ipfs.com
+
+RUN /builds/worker/bin/fetch-content static-url \
+    --sha256 daa17556c8690a34fb13af25c87ced89c79a36a935bf6126253a9d9a5226367c \
+    --size 2505205 \
+    https://hg.mozilla.org/mozilla-build/raw-file/3b8c537ca3c879551956ad47ca9f089583f647c5/nsis-3.01.zip \
+    /builds/worker/fetches/nsis-3.01.zip && \
+    cd /builds/worker/fetches/ && \
+    unzip nsis-3.01.zip && \
+    rm nsis-3.01.zip
+
+RUN /builds/worker/bin/fetch-content static-url \
+    --sha256 5c076f87ba64d82f11513f4af0ceb07246a3540aa3c72ca3ffc2d53971fa56e3 \
+    --size 462820 \
+    https://hg.mozilla.org/mozilla-build/raw-file/3b8c537ca3c879551956ad47ca9f089583f647c5/upx-3.95-win64.zip \
+    /builds/worker/fetches/upx-3.95-win64.zip && \
+    cd /builds/worker/fetches/ && \
+    unzip upx-3.95-win64.zip && \
+    rm upx-3.95-win64.zip
+
+RUN wget -nv -O /builds/worker/fetches/binutils.tar.xz $IPFS_GATEWAY/ipfs/QmfTyFzy9f61Est4wodKXvwKtPzDbsChWn6WknABjqXd99 && \
+    cd /builds/worker/fetches/ && \
+    tar -xf binutils.tar.xz && \
+    rm binutils.tar.xz
+
+RUN wget -nv -O /builds/worker/fetches/clang.tar.zst $IPFS_GATEWAY/ipfs/QmNS8jkq9w9DV6JH4kdYwN9g5QMyuy2qXPdrUWyQrWzr27 && \
+    cd /builds/worker/fetches/ && \
+    tar -xf clang.tar.zst && \
+    rm clang.tar.zst
+
+RUN wget -nv -O /builds/worker/fetches/rustc.tar.zst $IPFS_GATEWAY/ipfs/QmPvD66SV7nZKExzrPSR4m4VCvMQtBGahg1vN5Crv3i87C && \
+    cd /builds/worker/fetches/ && \
+    tar -xf rustc.tar.zst && \
+    rm rustc.tar.zst
+
+RUN wget -nv -O /builds/worker/fetches/rust-size.tar.xz $IPFS_GATEWAY/ipfs/QmaBFfnPsWcS1CFJ7ynd2fkkTcUTdg3nzLobVr67yicYub && \
+    cd /builds/worker/fetches/ && \
+    tar -xf rust-size.tar.xz && \
+    rm rust-size.tar.xz
+
+RUN wget -nv -O /builds/worker/fetches/nasm.tar.bz2 $IPFS_GATEWAY/ipfs/QmXkwK3DDQyUsJPRnaNG9mn74L2aMn2dWHWoC8d9CBiUTa && \
+    cd /builds/worker/fetches/ && \
+    tar -xf nasm.tar.bz2 && \
+    rm nasm.tar.bz2
+
+RUN wget -nv -O /builds/worker/fetches/node.tar.xz $IPFS_GATEWAY/ipfs/QmcPrE765WnKHryAF1s5FPdnoW6E6yYq4VzzUnLdZ5yMB3 && \
+    cd /builds/worker/fetches/ && \
+    tar -xf node.tar.xz && \
+    rm node.tar.xz
+
+RUN wget -nv -O /builds/worker/fetches/cbindgen.tar.xz $IPFS_GATEWAY/ipfs/QmVbXdagSvuQcbV1qTCdoU2gDqg8pALckngYok2pz4ze5P && \
+    cd /builds/worker/fetches/ && \
+    tar -xf cbindgen.tar.xz && \
+    rm cbindgen.tar.xz
+
+RUN wget -nv -O /builds/worker/fetches/sccache.tar.xz $IPFS_GATEWAY/ipfs/QmeB7fo2FuA9RNwK3fCRsHMD685HN9843HUfnHxw8S5iCt && \
+    cd /builds/worker/fetches/ && \
+    tar -xf sccache.tar.xz && \
+    rm sccache.tar.xz
+
+RUN wget -nv -O /builds/worker/fetches/dump_syms.tar.xz $IPFS_GATEWAY/ipfs/QmcBFu6XXN7qQbw8WDxdSqaX1F34ieScEbevhkQP4HGfZZ && \
+    cd /builds/worker/fetches/ && \
+    tar -xf dump_syms.tar.xz && \
+    rm dump_syms.tar.xz
+
+RUN wget -nv -O /builds/worker/fetches/wine.tar.xz $IPFS_GATEWAY/ipfs/QmNnUM1wbAzNfAAJmkXmyp2etev8ipG9Aw3pNwrtd7xHwr && \
+    cd /builds/worker/fetches/ && \
+    tar -xf wine.tar.xz && \
+    rm wine.tar.xz
+
+RUN wget -nv -O /builds/worker/fetches/liblowercase.tar.xz $IPFS_GATEWAY/ipfs/QmXsvLT12XWDwPpYpnJ1Z96vpJH9xG97Tax98v9oLNeuLe && \
+    cd /builds/worker/fetches/ && \
+    tar -xf liblowercase.tar.xz && \
+    rm liblowercase.tar.xz
+
+RUN wget -nv -O /builds/worker/fetches/winchecksec.tar.bz2 $IPFS_GATEWAY/ipfs/QmZkQu458RNKLkuwkGGuzVNhpbBE8W2gBkiaa2GHdfLCKD && \
+    cd /builds/worker/fetches/ && \
+    tar -xf winchecksec.tar.bz2 && \
+    rm winchecksec.tar.bz2
+
+RUN wget -nv -O /builds/worker/fetches/dump_syms.tar.bz2 $IPFS_GATEWAY/ipfs/QmWnwBGT8cL9JqFHuW8mjZXTdGaC9mfBRqGPaZaq6Mpc9d && \
+    cd /builds/worker/fetches/ && \
+    tar -xf dump_syms.tar.bz2 && \
+    rm dump_syms.tar.bz2
+
+ADD --chown=worker:worker makecab.exe /builds/worker/fetches/
+
+ENV MOZ_FETCHES_DIR=/builds/worker/fetches/ \
+    GECKO_PATH=/builds/worker/workspace \
+    WORKSPACE=/builds/worker/workspace \
+    TOOLTOOL_DIR=/builds/worker/fetches/ \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en
+
+COPY configs /builds/worker/configs
+
+WORKDIR $WORKSPACE

--- a/build/configs/win64-aarch64.mozconfig
+++ b/build/configs/win64-aarch64.mozconfig
@@ -1,0 +1,100 @@
+VSPATH=/builds/worker/fetches/vs2017_15.9.29
+export LLVM_CONFIG="${MOZ_FETCHES_DIR}/clang/bin/llvm-config"
+
+. $topsrcdir/build/mozconfig.win-common
+
+WINCHECKSEC="${MOZ_FETCHES_DIR}/winchecksec/winchecksec"
+
+ac_add_options --target=aarch64-windows-mingw32
+ac_add_options --enable-application=browser
+
+# build/mozconfig.common
+ac_add_options --enable-crashreporter
+# Disable enforcing that add-ons are signed by the trusted root
+MOZ_REQUIRE_SIGNING=${MOZ_REQUIRE_SIGNING-0}
+
+ac_add_options --enable-js-shell
+
+#. "$topsrcdir/build/mozconfig.nasm"
+NASM="${MOZ_FETCHES_DIR}/nasm/nasm"
+# end mozconfig.nasm
+#. "$topsrcdir/build/mozconfig.node"
+export NODEJS=$MOZ_FETCHES_DIR/node/bin/node
+# end mozconfig.node
+# skip . "$topsrcdir/build/mozconfig.automation"
+#. "$topsrcdir/build/mozconfig.rust"
+RUSTC="${MOZ_FETCHES_DIR}/rustc/bin/rustc"
+CARGO="${MOZ_FETCHES_DIR}/rustc/bin/cargo"
+RUSTDOC="${MOZ_FETCHES_DIR}/rustc/bin/rustdoc"
+RUSTFMT="${MOZ_FETCHES_DIR}/rustc/bin/rustfmt"
+CBINDGEN="${MOZ_FETCHES_DIR}/cbindgen/cbindgen"
+
+ac_add_options --enable-rust-simd
+# end mozconfig.rust
+# skip . "$topsrcdir/build/mozconfig.cache"
+# end build/mozconfig.common
+
+. $topsrcdir/build/win64/mozconfig.vs-latest
+
+#. $topsrcdir/browser/config/mozconfigs/win64/common-opt
+
+if test `uname -s` = Linux; then
+
+# Configure expects executables for check_prog, so set the relevant files
+# as executable on the first evaluation of the mozconfig where they exist.
+if [ -d "${VSPATH}" -a ! -x "${VSPATH}/VC/bin/Hostx64/x64/cl.exe" ]; then
+    find "${VSPATH}" -type f -name \*.exe -exec chmod +x {} \;
+fi
+export MAKENSISU="${MOZ_FETCHES_DIR}/nsis-3.01/makensis.exe"
+if [ -d "${MAKENSISU%/*}" -a ! -x "${MAKENSISU}" ]; then
+    chmod +x "${MAKENSISU}"
+fi
+export MAKECAB="${TOOLTOOL_DIR}/makecab.exe"
+if [ -f "${MAKECAB}" ]; then
+    chmod +x "${MAKECAB}"
+fi
+export UPX="${MOZ_FETCHES_DIR}/upx-3.95-win64/upx.exe"
+if [ -f "${UPX}" ]; then
+    chmod +x "${UPX}"
+fi
+export WINE=${MOZ_FETCHES_DIR}/wine/bin/wine64
+mk_add_options "export PATH=${VSPATH}/VC/bin/Hostx64/arm64:${MOZ_FETCHES_DIR}/nsis-3.01:${PATH}"
+mk_add_options "export WINEPATH=${VSPATH}/VC/bin/Hostx64/x64"
+
+unset VC_PATH
+
+fi
+
+export WINCHECKSEC="${MOZ_FETCHES_DIR}/winchecksec/winchecksec"
+if [ ! -f "${WINCHECKSEC}" ]; then
+    export WINCHECKSEC="${MOZ_FETCHES_DIR}/winchecksec/winchecksec.exe"
+    if [ ! -f "${WINCHECKSEC}" ]; then
+        unset WINCHECKSEC
+    fi
+fi
+
+export PDBSTR="${MOZ_FETCHES_DIR}/pdbstr/pdbstr.exe"
+if [ -f "${PDBSTR}" ]; then
+    chmod +x "${PDBSTR}"
+else
+    unset PDBSTR
+fi
+
+unset VC_PATH
+DUMP_SYMS=/builds/worker/fetches/dump_syms/dump_syms
+
+ac_add_options --enable-jemalloc
+
+LINKER=lld-link
+MOZ_PACKAGE_JSSHELL=1
+
+export CC=clang-cl
+export CXX=clang-cl
+export ENABLE_CLANG_PLUGIN=1
+
+# disable tests for this build
+ac_add_options --disable-tests
+
+if [ -n "$PGO_PROFILE_GENERATE" ]; then
+    ac_add_options --enable-profile-generate=cross
+fi

--- a/build/configs/win64.mozconfig
+++ b/build/configs/win64.mozconfig
@@ -1,4 +1,4 @@
-VSPATH=/builds/worker/fetches/vs2017_15.8.4
+VSPATH=/builds/worker/fetches/vs2017_15.9.29
 export LLVM_CONFIG="${MOZ_FETCHES_DIR}/clang/bin/llvm-config"
 
 . $topsrcdir/build/mozconfig.win-common

--- a/ci.multibranch.Jenkinsfile
+++ b/ci.multibranch.Jenkinsfile
@@ -4,6 +4,7 @@ properties([
         booleanParam(name: 'Clobber', defaultValue: false, description: 'run mach clobber'),
         booleanParam(name: 'Linux64', defaultValue: true, description: ''),
         booleanParam(name: 'Windows64', defaultValue: true, description: ''),
+        booleanParam(name: 'WindowsARM', defaultValue: false, description: ''),
         booleanParam(name: 'MacOSX64', defaultValue: true, description: ''),
         string(name: 'ReleaseName', defaultValue: '', description: ''),
         booleanParam(name: 'Nightly', defaultValue: false, description: 'Push release to nightly'),
@@ -79,6 +80,30 @@ if (params.Windows64) {
 
     if (shouldRelease) {
         signmatrix["Sign ${name}"] = helpers.windows_signing(name, objDir, artifactGlob)
+    }
+}
+
+if (params.WindowsARM) {
+    def name = 'WindowsARM'
+    def objDir = 'obj-aarch64-windows-mingw32'
+    def artifactGlob = "$objDir/dist/install/**/*"
+
+    buildmatrix[name] = {
+        node('docker && magrathea') {
+            helpers.build(name, 'WindowsARM.dockerfile', 'win64-aarch64', objDir, params, buildId)()
+
+            archiveArtifacts artifacts: "mozilla-release/$objDir/dist/update/*.mar"
+            archiveArtifacts artifacts: "mozilla-release/${artifactGlob}"
+
+            stash name: name, includes: [
+                "mozilla-release/${artifactGlob}",
+                "mozilla-release/browser/config/version.txt",
+                "mozilla-release/other-licenses/7zstub/firefox/*",
+                "mozilla-release/browser/installer/windows/*",
+            ].join(',')
+
+            sh "rm -rf mozilla-release/$objDir/dist/update"
+        }
     }
 }
 

--- a/ci.multibranch.Jenkinsfile
+++ b/ci.multibranch.Jenkinsfile
@@ -105,6 +105,10 @@ if (params.WindowsARM) {
             sh "rm -rf mozilla-release/$objDir/dist/update"
         }
     }
+
+    if (shouldRelease) {
+        signmatrix["Sign ${name}"] = helpers.windows_signing(name, objDir, artifactGlob)
+    }
 }
 
 if (params.MacOSX64) {

--- a/ci.nightly.Jenkinsfile
+++ b/ci.nightly.Jenkinsfile
@@ -45,6 +45,7 @@ if (!tagExists) {
         booleanParam(name: 'Linux64', value: true),
         booleanParam(name: 'Windows64', value: true),
         booleanParam(name: 'MacOSX64', value: true),
+        booleanParam(name: 'WindowsARM', value: true),
         booleanParam(name: 'Nightly', value: true),
         booleanParam(name: 'PGO',  value: true),
     ], propagate: false, wait: false

--- a/ci/bootstrap_windows.sh
+++ b/ci/bootstrap_windows.sh
@@ -4,7 +4,7 @@ set -e
 set -x
 
 ARTIFACT_PATH="/c/build"
-package="vs2017_15.9.10"
+package="vs2017_15.9.29"
 
 mkdir -p $ARTIFACT_PATH
 

--- a/ci/build-helpers.groovy
+++ b/ci/build-helpers.groovy
@@ -19,7 +19,7 @@ def build(name, dockerFile, targetPlatform, objDir, params, buildId, buildEnv=[]
             docker.build("ua-build-${name.toLowerCase()}", "-f build/${dockerFile} ./build --build-arg IPFS_GATEWAY=http://kria.cliqz:8080")
         }
 
-        image.inside("-v /mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4") {
+        image.inside("-v /mnt/vfat/vs2017_15.9.29/:/builds/worker/fetches/vs2017_15.9.29") {
             withEnv(["MACH_USE_SYSTEM_PYTHON=1", "MOZCONFIG=${env.WORKSPACE}/mozconfig", "MOZ_BUILD_DATE=${buildId}"]) {
                 stage('prepare mozilla-release') {
                     sh 'npm ci'

--- a/ci/uadpy/common.py
+++ b/ci/uadpy/common.py
@@ -19,6 +19,7 @@ build_target_to_platform = {
     'Darwin_x86_64-gcc3': 'mac',
     'WINNT_x86_64-msvc-x64': 'win64',
     'Linux_x86_64-gcc3': 'linux-x86_64',
+    'WINNT_aarch64-msvc-aarch64': 'win64-aarch64',
 }
 platform_to_build_target = {
     v: k for k, v in build_target_to_platform.items()

--- a/fern/commands/build.js
+++ b/fern/commands/build.js
@@ -286,7 +286,7 @@ module.exports = (program) => {
           {
             title: "Check Windows 10 SDK exists",
             task: async () => {
-              const sdk = "vs2017_15.8.4.zip";
+              const sdk = "vs2017_15.9.29.zip";
               if ((await fileExists(path.join(buildFolder, sdk))) === false) {
                 throw new Error(
                   `Windows 10 SDK must be available at build/${sdk}`
@@ -320,9 +320,9 @@ module.exports = (program) => {
           },
           {
             title: "Extract Windows 10 SDK to VFAT Drive",
-            skip: () => folderExists("/mnt/vfat/vs2017_15.8.4"),
+            skip: () => folderExists("/mnt/vfat/vs2017_15.9.29"),
             task: async () => {
-              const vs2017 = "vs2017_15.8.4.zip";
+              const vs2017 = "vs2017_15.9.29.zip";
               await fsExtra.copy(
                 path.join(buildFolder, vs2017),
                 `/mnt/vfat/${vs2017}`
@@ -344,7 +344,7 @@ module.exports = (program) => {
                 out: logWriter,
                 registerCleanupTask,
                 Binds: [
-                  "/mnt/vfat/vs2017_15.8.4/:/builds/worker/fetches/vs2017_15.8.4",
+                  "/mnt/vfat/vs2017_15.9.29/:/builds/worker/fetches/vs2017_15.9.29",
                   `${path.join(
                     buildFolder,
                     "makecab.exe"

--- a/fern/core/docker.js
+++ b/fern/core/docker.js
@@ -184,6 +184,19 @@ async function generate(artifactBaseDir) {
         "macosx.yml"
       ),
     },
+    {
+      name: "WindowsARM",
+      key: "win64-aarch64/opt",
+      arch: 'arm64',
+      buildPath: path.join(
+        root,
+        "mozilla-release",
+        "taskcluster",
+        "ci",
+        "build",
+        "windows.yml"
+      ),
+    },
   ];
   // Collect the toolchains required for each build from it's specification in taskcluster configs.
   const buildInfos = await Promise.all(


### PR DESCRIPTION
- [x] Updates Windows SDK to one which includes ARM64 tools
- [x] Add dockerfile with windows ARM toolchain, based on firefox `win64-aarch64/opt` build
- [x] Add win64-aarch64 mozconfig.
- [x] Add ARM build to build matrix. By default disabled.
- [x] Determine build target name for balrog
- [x] Support upload to balrog
- [ ] ~~Linux aarch64~~

Note, while I have the aarch64 build for Linux also working, I'm omitting it as there doesn't seem to be a target audience for it. This avoids the extra work needed to support linux ARM builds---they require changes to the base image to get arm libraries, while for the windows builds we don't need that as everything is in the SDK.