### PR TITLE
Ghostery Extension version bump

### DIFF
--- a/.workspace
+++ b/.workspace
@@ -1,6 +1,6 @@
 {
   "addons": {
-    "ghostery": "https://ghostery-deployments.s3.amazonaws.com/ghostery-extension/8.5.4.5bf5c45f/ghostery-firefox-v8.5.4.zip",
+    "ghostery": "https://s3.amazonaws.com/ghostery-deployments/ghostery-extension/8.5.4.84635166/ghostery-firefox-v8.5.4.84635166.xpi",
     "ghostery-search": "https://github.com/ghostery/ghostery-search-extension/releases/download/v0.1.15/ghostery_search-0.1.15.zip"
   },
   "firefox": "83.0",


### PR DESCRIPTION
This version removed MyOfferz integration completely and should disable Ghostery  Extension onboarding. 