### PR TITLE
Hide learn more link on network error pages.

### DIFF
--- a/patches/.index
+++ b/patches/.index
@@ -35,3 +35,4 @@
 0035-Update-text-on-about-license.patch
 0036-Hide-addon-recommendation-badge.patch
 0037-Disable-ion-pioneer-studies.patch
+0038-Hide-learn-more-link-on-network-error-pages.patch

--- a/patches/0038-Hide-learn-more-link-on-network-error-pages.patch
+++ b/patches/0038-Hide-learn-more-link-on-network-error-pages.patch
@@ -1,0 +1,26 @@
+From: Sam Macbeth <sam@cliqz.com>
+Date: Thu, 19 Nov 2020 17:20:16 +0100
+Subject: Hide learn more link on network error pages
+
+---
+ browser/themes/shared/aboutNetError.css | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/browser/themes/shared/aboutNetError.css b/browser/themes/shared/aboutNetError.css
+index 4a5c164638..172e9f0471 100644
+--- a/browser/themes/shared/aboutNetError.css
++++ b/browser/themes/shared/aboutNetError.css
+@@ -4,6 +4,10 @@
+ 
+ @import url("chrome://browser/skin/error-pages.css");
+ 
++#learnMoreLink {
++  display: none;
++}
++
+ body.certerror {
+   width: 100%;
+   justify-content: normal;
+-- 
+2.29.2
+


### PR DESCRIPTION
Example test page: https://wrong.host.badssl.com/