### PR TITLE
Remove human-web references

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Windows and Mac builds depend on platform frameworks being included. These shoul
 
 ## Development workflow
 
-After cloning the [repository](https://github.com/human-web/user-agent-desktop),
+After cloning the [repository](https://github.com/ghostery/user-agent-desktop),
 run the following commands to get started (Note that you will need `npm` and
 `node` to be installed on your system):
 

--- a/ci.multibranch.Jenkinsfile
+++ b/ci.multibranch.Jenkinsfile
@@ -285,7 +285,7 @@ stage('publish to github') {
                     def artifactName = artifactPath.split('/').last()
                     sh """
                         github-release upload \
-                            --user human-web \
+                            --user ghostery \
                             --repo user-agent-desktop \
                             --tag "${params.ReleaseName}" \
                             --name "${artifactName}" \

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/human-web/user-agent-desktop.git"
+    "url": "git+https://github.com/ghostery/user-agent-desktop.git"
   },
   "author": "",
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/human-web/user-agent-desktop/issues"
+    "url": "https://github.com/ghostery/user-agent-desktop/issues"
   },
-  "homepage": "https://github.com/human-web/user-agent-desktop#readme",
+  "homepage": "https://github.com/ghostery/user-agent-desktop#readme",
   "devDependencies": {
     "appdmg": "^0.6.0",
     "chalk": "^4.1.0",


### PR DESCRIPTION
human-web was a temporal github organization hosting first iteration of user-agent-desktop project and it does not exist anymore.