### PR TITLE
Rebranding follow up

### DIFF
--- a/brands/ghostery/branding/locales/en-US/brand.dtd
+++ b/brands/ghostery/branding/locales/en-US/brand.dtd
@@ -2,10 +2,10 @@
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 
-<!ENTITY  brandShorterName      "Ghostery">
-<!ENTITY  brandShortName        "Ghostery">
+<!ENTITY  brandShorterName      "Dawn">
+<!ENTITY  brandShortName        "Ghostery Dawn">
 <!ENTITY  brandFullName         "Ghostery Dawn">
 <!-- LOCALIZATION NOTE (brandProductName):
    This brand name can be used in messages where the product name needs to
    remain unchanged across different versions (Nightly, Beta, etc.). -->
-<!ENTITY  brandProductName      "Ghostery">
+<!ENTITY  brandProductName      "Ghostery Dawn">

--- a/brands/ghostery/branding/locales/en-US/brand.properties
+++ b/brands/ghostery/branding/locales/en-US/brand.properties
@@ -2,13 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-brandShorterName=Ghostery
-brandShortName=Ghostery
-brandFullName=Ghostery
+brandShorterName=Dawn
+brandShortName=Ghostery Dawn
+brandFullName=Ghostery Dawn
 # LOCALIZATION NOTE(brandProductName):
 # This brand name can be used in messages where the product name needs to
 # remain unchanged across different versions (Nightly, Beta, etc.).
-brandProductName=Ghostery
-vendorShortName= Ghostery Inc
+brandProductName=Ghostery Dawn
+vendorShortName=Ghostery Inc
 
 syncBrandShortName=Sync


### PR DESCRIPTION
In quite few places the browser is still referencing to itself as to `Ghostery` which may be misleading to some users.