### PR TITLE
New New Tab Page

### DIFF
--- a/.workspace
+++ b/.workspace
@@ -1,8 +1,9 @@
 {
   "addons": {
     "ghostery": "https://ghostery-deployments.s3.amazonaws.com/ghostery-extension/8.5.5.391bc6d0/ghostery-firefox-v8.5.5.xpi",
-    "ghostery-search": "https://github.com/ghostery/ghostery-search-extension/releases/download/v0.2.3/ghostery_glow-0.2.3.zip"
-  },
+    "ghostery-search": "https://github.com/ghostery/ghostery-search-extension/releases/download/v0.2.3/ghostery_glow-0.2.3.zip",
+    "ghostery-newtab": "https://github.com/ghostery/ghostery-newtab-extension/releases/download/v0.0.2/ghostery_new_tab-0.0.2.zip"
+ },
   "firefox": "84.0.2",
   "app": "2021.01.2",
   "ipfsAddr": "/ipfs/QmNk1gRGTUy6hPtgtwew2q3kDdBgaEYvaWEGfbMUHi2roc",

--- a/patches/.index
+++ b/patches/.index
@@ -35,3 +35,4 @@
 0035-Remove-Firefox-strings-for-new-install-page.patch
 0036-OpenURL-on-buildID-changes.patch
 0037-Ignore-the-glinter.patch
+0038-Replace-New-Tab-with-Ghostery-New-Tab-Addon.patch

--- a/patches/0001-Include-addons-in-browser-bundle.patch
+++ b/patches/0001-Include-addons-in-browser-bundle.patch
@@ -7,7 +7,7 @@ Subject: Include addons in browser bundle
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/browser/extensions/moz.build b/browser/extensions/moz.build
-index 0eb3c53e76..6f2bb59d8e 100644
+index 0eb3c53e76..b37208ee92 100644
 --- a/browser/extensions/moz.build
 +++ b/browser/extensions/moz.build
 @@ -4,4 +4,4 @@
@@ -15,7 +15,7 @@ index 0eb3c53e76..6f2bb59d8e 100644
  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
  
 -DIRS += ["doh-rollout", "formautofill", "screenshots", "webcompat", "report-site-issue"]
-+DIRS += ["doh-rollout", "formautofill", "screenshots", "webcompat", "report-site-issue", "ghostery", "ghostery-search"]
++DIRS += ["doh-rollout", "formautofill", "screenshots", "webcompat", "report-site-issue", "ghostery", "ghostery-search", "ghostery-newtab"]
 -- 
 2.29.2
 

--- a/patches/0003-Change-new-tab-page-and-home-page-url.patch
+++ b/patches/0003-Change-new-tab-page-and-home-page-url.patch
@@ -4,13 +4,12 @@ Subject: Change new tab page and home page url
 
 ---
  browser/app/profile/firefox.js                   |  2 +-
- browser/base/content/browser.js                  |  2 ++
  browser/components/newtab/AboutNewTabService.jsm | 15 +--------------
  browser/modules/HomePage.jsm                     |  2 +-
- 4 files changed, 5 insertions(+), 16 deletions(-)
+ 3 files changed, 3 insertions(+), 16 deletions(-)
 
 diff --git a/browser/app/profile/firefox.js b/browser/app/profile/firefox.js
-index 2588a53cf2..99b2127ca1 100644
+index 2588a53cf2..3537031a5b 100644
 --- a/browser/app/profile/firefox.js
 +++ b/browser/app/profile/firefox.js
 @@ -253,7 +253,7 @@ pref("browser.defaultbrowser.notificationbar.checklimit", 10000);
@@ -18,25 +17,12 @@ index 2588a53cf2..99b2127ca1 100644
  // The behavior of option 3 is detailed at: http://wiki.mozilla.org/Session_Restore
  pref("browser.startup.page",                1);
 -pref("browser.startup.homepage",            "about:home");
-+pref("browser.startup.homepage",            "https://glowstery.com/");
++pref("browser.startup.homepage",            "https://ghostery.com/");
  #ifdef NIGHTLY_BUILD
  pref("browser.startup.homepage.abouthome_cache.enabled", true);
  #else
-diff --git a/browser/base/content/browser.js b/browser/base/content/browser.js
-index 8d1b0d9d99..5ac65907a6 100644
---- a/browser/base/content/browser.js
-+++ b/browser/base/content/browser.js
-@@ -635,6 +635,8 @@ var gInitialPages = [
-   "about:sessionrestore",
-   "about:welcome",
-   "about:newinstall",
-+  "https://glowstery.com/",
-+  "https://ghosterysearch.com/",
- ];
-
- function isInitialPage(url) {
 diff --git a/browser/components/newtab/AboutNewTabService.jsm b/browser/components/newtab/AboutNewTabService.jsm
-index a11f69cf16..a35201a9c6 100644
+index a11f69cf16..c8c42c876d 100644
 --- a/browser/components/newtab/AboutNewTabService.jsm
 +++ b/browser/components/newtab/AboutNewTabService.jsm
 @@ -350,20 +350,7 @@ class BaseAboutNewTabService {
@@ -57,23 +43,23 @@ index a11f69cf16..a35201a9c6 100644
 -      this.privilegedAboutProcessEnabled ? "-noscripts" : "",
 -      ".html",
 -    ].join("");
-+    return "https://glowstery.com/";
++    return "https://ghostery.com/";
    }
-
+ 
    get welcomeURL() {
 diff --git a/browser/modules/HomePage.jsm b/browser/modules/HomePage.jsm
-index c903787fde..bbeff85841 100644
+index c903787fde..52b5b61ee5 100644
 --- a/browser/modules/HomePage.jsm
 +++ b/browser/modules/HomePage.jsm
 @@ -20,7 +20,7 @@ XPCOMUtils.defineLazyModuleGetters(this, {
  });
-
+ 
  const kPrefName = "browser.startup.homepage";
 -const kDefaultHomePage = "about:home";
-+const kDefaultHomePage = "https://glowstery.com/";
++const kDefaultHomePage = "https://ghostery.com/";
  const kExtensionControllerPref =
    "browser.startup.homepage_override.extensionControlled";
  const kHomePageIgnoreListId = "homepage-urls";
---
+-- 
 2.29.2
 

--- a/patches/0005-Remove-bundled-mozilla-extensions.patch
+++ b/patches/0005-Remove-bundled-mozilla-extensions.patch
@@ -7,15 +7,15 @@ Subject: Remove bundled mozilla extensions
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/browser/extensions/moz.build b/browser/extensions/moz.build
-index 6f2bb59d8e..7b27ed61ab 100644
+index b37208ee92..0702dd747f 100644
 --- a/browser/extensions/moz.build
 +++ b/browser/extensions/moz.build
 @@ -4,4 +4,4 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
  
--DIRS += ["doh-rollout", "formautofill", "screenshots", "webcompat", "report-site-issue", "ghostery", "ghostery-search"]
-+DIRS += ["webcompat", "report-site-issue", "ghostery", "ghostery-search"]
+-DIRS += ["doh-rollout", "formautofill", "screenshots", "webcompat", "report-site-issue", "ghostery", "ghostery-search", "ghostery-newtab"]
++DIRS += ["webcompat", "report-site-issue", "ghostery", "ghostery-search", "ghostery-newtab"]
 -- 
 2.29.2
 

--- a/patches/0038-Replace-New-Tab-with-Ghostery-New-Tab-Addon.patch
+++ b/patches/0038-Replace-New-Tab-with-Ghostery-New-Tab-Addon.patch
@@ -1,0 +1,56 @@
+From: Krzysztof Jan Modras <chrmod@chrmod.net>
+Date: Thu, 28 Jan 2021 12:45:28 +0100
+Subject: Replace New Tab with Ghostery New Tab Addon
+
+---
+ browser/components/extensions/parent/ext-url-overrides.js | 2 +-
+ browser/components/urlbar/UrlbarInput.jsm                 | 7 +++++++
+ browser/themes/shared/preferences/preferences.inc.css     | 4 ++++
+ 3 files changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/browser/components/extensions/parent/ext-url-overrides.js b/browser/components/extensions/parent/ext-url-overrides.js
+index 5933552a98..ec8c30579e 100644
+--- a/browser/components/extensions/parent/ext-url-overrides.js
++++ b/browser/components/extensions/parent/ext-url-overrides.js
+@@ -74,7 +74,7 @@ XPCOMUtils.defineLazyGetter(this, "newTabPopup", () => {
+ });
+ 
+ function setNewTabURL(extensionId, url) {
+-  if (extensionId) {
++  if (extensionId && extensionId !== 'newtab@ghostery.com') {
+     newTabPopup.addObserver(extensionId);
+     let policy = ExtensionParent.WebExtensionPolicy.getByID(extensionId);
+     Services.prefs.setBoolPref(
+diff --git a/browser/components/urlbar/UrlbarInput.jsm b/browser/components/urlbar/UrlbarInput.jsm
+index 54ef157d1e..6cd9c126ba 100644
+--- a/browser/components/urlbar/UrlbarInput.jsm
++++ b/browser/components/urlbar/UrlbarInput.jsm
+@@ -347,6 +347,13 @@ class UrlbarInput {
+ 
+       valid =
+         !this.window.isBlankPageURL(uri.spec) || uri.schemeIs("moz-extension");
++      try {
++        const { WebExtensionPolicy } = Cu.getGlobalForObject(Services);
++        const policy = WebExtensionPolicy.getByURI(uri);
++        if (policy.id === 'newtab@ghostery.com') {
++          valid = false;
++        }
++      } catch (e) {}
+     } else if (
+       this.window.isInitialPage(value) &&
+       BrowserUtils.checkEmptyPageOrigin(this.window.gBrowser.selectedBrowser)
+diff --git a/browser/themes/shared/preferences/preferences.inc.css b/browser/themes/shared/preferences/preferences.inc.css
+index 5cd43e4fab..ecd808b068 100644
+--- a/browser/themes/shared/preferences/preferences.inc.css
++++ b/browser/themes/shared/preferences/preferences.inc.css
+@@ -1152,3 +1152,7 @@ richlistitem .text-link:hover {
+ .featureGateDescription {
+   margin-inline-start: 28px;
+ }
++
++#category-home {
++  display: none;
++}
+-- 
+2.29.2
+


### PR DESCRIPTION
This PR replaces landing page of Ghostery Glow in a role of New Tab Page with a dedicated addon.

Light theme:
<img width="1372" alt="Screenshot 2021-01-28 at 17 26 01" src="https://user-images.githubusercontent.com/1228153/106169310-8a185480-618f-11eb-884c-ddcfe654be1d.png">

Dark theme:
<img width="1375" alt="Screenshot 2021-01-28 at 17 26 10" src="https://user-images.githubusercontent.com/1228153/106169329-8d134500-618f-11eb-80d5-828c778a3240.png">
