### PR TITLE
Ghostery Addon version bump

### DIFF
--- a/.workspace
+++ b/.workspace
@@ -1,6 +1,6 @@
 {
   "addons": {
-    "ghostery": "https://ghostery-deployments.s3.amazonaws.com/ghostery-extension/8.5.5.71266e47/ghostery-dawn-v8.5.5.71266e47.xpi",
+    "ghostery": "https://ghostery-deployments.s3.amazonaws.com/ghostery-extension/8.5.5.f13e50d7/ghostery-firefox-v8.5.5.xpi",
     "ghostery-search": "https://github.com/ghostery/ghostery-search-extension/releases/download/v0.2.4/ghostery_glow-0.2.4.zip",
     "ghostery-newtab": "https://github.com/ghostery/ghostery-newtab-extension/releases/download/v0.1.0/ghostery_new_tab-0.1.0.zip"
   },

--- a/patches/0029-Add-DNS-search-and-websocket-permissions-to-ghostery.patch
+++ b/patches/0029-Add-DNS-search-and-websocket-permissions-to-ghostery.patch
@@ -3,31 +3,26 @@ Date: Fri, 30 Oct 2020 11:12:49 +0100
 Subject: Add DNS, search and websocket permissions to ghostery extension
 
 ---
- browser/extensions/ghostery/manifest.json | 6 ++++--
- 1 file changed, 4 insertions(+), 2 deletions(-)
+ browser/extensions/ghostery/manifest.json | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/browser/extensions/ghostery/manifest.json b/browser/extensions/ghostery/manifest.json
-index aa658e3a30..2d4518a448 100644
+index 3f4ceb797a..489384f729 100644
 --- a/browser/extensions/ghostery/manifest.json
 +++ b/browser/extensions/ghostery/manifest.json
-@@ -72,7 +72,9 @@
+@@ -70,7 +70,11 @@
+ 		"tabs",
+ 		"http://*/*",
  		"https://*/*",
- 		"ws://*/*",
- 		"wss://*/*",
 -		"storage"
 +		"storage",
++		"dns",
 +		"search",
-+		"dns"
++		"ws://*/*",
++		"wss://*/*"
  	],
  	"background": {
  		"scripts": [
-@@ -88,4 +90,4 @@
- 	"web_accessible_resources": [
- 		"app/images/*"
- 	]
--}
-\ No newline at end of file
-+}
 -- 
-2.30.0
+2.29.2
 


### PR DESCRIPTION
Reverts ghostery/user-agent-desktop#478 as new build is again a firefox one.

fixes:
* Next button on Search Selection screen works again
* Safer handling of unknown search engine names
* Setting Startpage works (again)