### PR TITLE
Limit code to Ghostery updates, search, etc.

### DIFF
--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -55,6 +55,10 @@ pref("privacy.trackingprotection.cryptomining.enabled", false);
 pref("privacy.trackingprotection.fingerprinting.enabled", false);
 pref("privacy.trackingprotection.socialtracking.enabled", false);
 pref("privacy.socialtracking.block_cookies.enabled", false);
+pref("browser.contentblocking.database.enabled", false);
+pref("browser.contentblocking.allowlist.storage.enabled", false);
+pref("browser.contentblocking.cryptomining.preferences.ui.enabled", false);
+pref("browser.contentblocking.fingerprinting.preferences.ui.enabled", false);
 
 // Remove addons.mozilla.org from set of domains that extensions cannot access
 pref("extensions.webextensions.restrictedDomains", "accounts-static.cdn.mozilla.net,accounts.firefox.com,addons.cdn.mozilla.net,api.accounts.firefox.com,content.cdn.mozilla.net,discovery.addons.mozilla.org,install.mozilla.org,oauth.accounts.firefox.com,profile.accounts.firefox.com,support.mozilla.org,sync.services.mozilla.com");
@@ -85,6 +89,8 @@ pref("breakpad.reportURL", "");
 pref("browser.tabs.crashReporting.sendReport", false);
 pref("browser.crashReports.unsubmittedCheck.enabled", false);
 pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false);
+pref("browser.newtabpage.activity-stream.feeds.telemetry", false);
+pref("browser.newtabpage.activity-stream.telemetry", false);
 pref("extensions.abuseReport.enabled", false);
 pref("corroborator.enabled", false)
 

--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -118,9 +118,6 @@ pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features", false
 pref("extensions.htmlaboutaddons.recommendations.enabled", false);
 pref("extensions.getAddons.showPane", false);
 
-// Disable System Addon updates
-pref("extensions.systemAddon.update.url", "");
-
 /** HOMEPAGE ***/
 pref("startup.homepage_override_url", "");
 pref("startup.homepage_welcome_url", "");

--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -80,6 +80,8 @@ pref("toolkit.telemetry.shutdownPingSender.enabled", false);
 pref("toolkit.telemetry.updatePing.enabled", false);
 pref("toolkit.telemetry.bhrPing.enabled", false);
 pref("toolkit.telemetry.firstShutdownPing.enabled", false);
+
+// Corroborator (#141)
 pref("corroborator.enabled", false)
 
 // Telemetry Coverage
@@ -88,13 +90,16 @@ pref("toolkit.coverage.opt-out", true);
 pref("toolkit.coverage.endpoint.base", "");
 
 // Health Reports
-// Privacy & Security>Firefox Data Collection & Use>Allow Firefox to send technical data.
+// [SETTING] Privacy & Security>Firefox Data Collection & Use>Allow Firefox to send technical data.
 pref("datareporting.healthreport.uploadEnabled", false);
 
 // New data submission, master kill switch
+// If disabled, no policy is shown or upload takes place, ever
+// [1] https://bugzilla.mozilla.org/1195552 ***/
 pref("datareporting.policy.dataSubmissionEnabled", false);
 
 // Studies
+// [SETTING] Privacy & Security>Firefox Data Collection & Use>Allow Firefox to install and run studies
 pref("app.shield.optoutstudies.enabled", false);
 
 // Personalized Extension Recommendations in about:addons and AMO

--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -64,20 +64,13 @@ pref("browser.contentblocking.fingerprinting.preferences.ui.enabled", false);
 pref("extensions.webextensions.restrictedDomains", "accounts-static.cdn.mozilla.net,accounts.firefox.com,addons.cdn.mozilla.net,api.accounts.firefox.com,content.cdn.mozilla.net,discovery.addons.mozilla.org,install.mozilla.org,oauth.accounts.firefox.com,profile.accounts.firefox.com,support.mozilla.org,sync.services.mozilla.com");
 
 // Disable System Addon updates
-// [NOTE] We currently don't use partial updates instead of system addon updates
+// [NOTE] We use partial updates instead of system addon updates.
 pref("extensions.systemAddon.update.url", "");
 
-/** TELEMETRY, STUDIES, EXPERIMENTS, CRASH REPORTS ***/
-// See https://github.com/yokoffing/Better-Fox/blob/a458e14a94ff67111868178639c188a5d08f7038/SecureFox.js#L510
-// for details.
-// [NOTE] We may need re-enable and/or redirect some of these for Ghostery Dawn.
-pref("datareporting.policy.dataSubmissionEnabled", false);
-pref("datareporting.healthreport.uploadEnabled", false);
-pref("browser.ping-centre.telemetry", false);
-pref("default-browser-agent.enabled", false);
-pref("app.shield.optoutstudies.enabled", false);
-pref("app.normandy.enabled", false);
-pref("app.normandy.api_url", "");
+
+/** TELEMETRY ***/
+
+// Telemtry
 pref("toolkit.telemetry.unified", false);
 pref("toolkit.telemetry.enabled", false);
 pref("toolkit.telemetry.server", "data:,");
@@ -87,18 +80,64 @@ pref("toolkit.telemetry.shutdownPingSender.enabled", false);
 pref("toolkit.telemetry.updatePing.enabled", false);
 pref("toolkit.telemetry.bhrPing.enabled", false);
 pref("toolkit.telemetry.firstShutdownPing.enabled", false);
+pref("corroborator.enabled", false)
+
+// Telemetry Coverage
 pref("toolkit.telemetry.coverage.opt-out", true);
 pref("toolkit.coverage.opt-out", true);
 pref("toolkit.coverage.endpoint.base", "");
+
+// Health Reports
+// Privacy & Security>Firefox Data Collection & Use>Allow Firefox to send technical data.
+pref("datareporting.healthreport.uploadEnabled", false);
+
+// New data submission, master kill switch
+pref("datareporting.policy.dataSubmissionEnabled", false);
+
+// Studies
+pref("app.shield.optoutstudies.enabled", false);
+
+// Personalized Extension Recommendations in about:addons and AMO
+// [NOTE] This pref has no effect when Health Reports are disabled.
+// [SETTING] Privacy & Security>Firefox Data Collection & Use>Allow Firefox to make personalized extension recommendations
 pref("browser.discovery.enabled", false);
+
+// Crash Reports
 pref("breakpad.reportURL", "");
 pref("browser.tabs.crashReporting.sendReport", false);
 pref("browser.crashReports.unsubmittedCheck.enabled", false);
+// backlogged crash reports
 pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false);
+
+// disable Captive Portal detection
+// [1] https://www.eff.org/deeplinks/2017/08/how-captive-portals-interfere-wireless-security-and-privacy
+// [2] https://wiki.mozilla.org/Necko/CaptivePortal
+// user_pref("captivedetect.canonicalURL", "");
+// user_pref("network.captive-portal-service.enabled", false);
+
+// disable Network Connectivity checks
+// [1] https://bugzilla.mozilla.org/1460537
+// user_pref("network.connectivity-service.enabled", false);
+
+// Software that continually reports what default browser you are using
+pref("default-browser-agent.enabled", false);
+
+// Report extensions for abuse
+pref("extensions.abuseReport.enabled", false);
+
+// Normandy/Shield [extensions tracking]
+// Shield is an telemetry system (including Heartbeat) that can also push and test "recipes"
+pref("app.normandy.enabled", false);
+pref("app.normandy.api_url", "");
+
+// disable PingCentre telemetry (used in several System Add-ons)
+// Currently blocked by 'datareporting.healthreport.uploadEnabled'
+pref("browser.ping-centre.telemetry", false);
+
+// disable Activity Stream telemetry 
 pref("browser.newtabpage.activity-stream.feeds.telemetry", false);
 pref("browser.newtabpage.activity-stream.telemetry", false);
-pref("extensions.abuseReport.enabled", false);
-pref("corroborator.enabled", false)
+
 
 // Disable Firefox-specifc menus and products
 pref("browser.privatebrowsing.vpnpromourl", ""); // Mozilla VPN
@@ -107,12 +146,11 @@ pref("extensions.pocket.enabled", false); // Pocket Account
 pref("extensions.pocket.api"," ");
 pref("extensions.pocket.oAuthConsumerKey", " ");
 pref("extensions.pocket.site", " ");
-pref("identity.fxaccounts.enabled", false); // Firefox Accounts & Sync [FF60+] [RESTART]
+pref("identity.fxaccounts.enabled", false); // Firefox Accounts & Sync
 pref("extensions.fxmonitor.enabled", false); // Firefox Monitor
 pref("signon.management.page.breach-alerts.enabled", false); // Firefox Lockwise
 pref("signon.management.page.breachAlertUrl", "");
-// PREF: Disable Extension Recommendations (CFR: "Contextual Feature Recommender")
-// [1] https://support.mozilla.org/en-US/kb/extension-recommendations
+// Disable Extension Recommendations (CFR: "Contextual Feature Recommender")
 pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons", false);
 pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features", false);
 pref("extensions.htmlaboutaddons.recommendations.enabled", false);

--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -63,6 +63,10 @@ pref("browser.contentblocking.fingerprinting.preferences.ui.enabled", false);
 // Remove addons.mozilla.org from set of domains that extensions cannot access
 pref("extensions.webextensions.restrictedDomains", "accounts-static.cdn.mozilla.net,accounts.firefox.com,addons.cdn.mozilla.net,api.accounts.firefox.com,content.cdn.mozilla.net,discovery.addons.mozilla.org,install.mozilla.org,oauth.accounts.firefox.com,profile.accounts.firefox.com,support.mozilla.org,sync.services.mozilla.com");
 
+// Disable System Addon updates
+// [NOTE] We currently don't use partial updates instead of system addon updates
+pref("extensions.systemAddon.update.url", "");
+
 /** TELEMETRY, STUDIES, EXPERIMENTS, CRASH REPORTS ***/
 // See https://github.com/yokoffing/Better-Fox/blob/a458e14a94ff67111868178639c188a5d08f7038/SecureFox.js#L510
 // for details.
@@ -76,6 +80,7 @@ pref("app.normandy.enabled", false);
 pref("app.normandy.api_url", "");
 pref("toolkit.telemetry.unified", false);
 pref("toolkit.telemetry.enabled", false);
+pref("toolkit.telemetry.server", "data:,");
 pref("toolkit.telemetry.archive.enabled", false);
 pref("toolkit.telemetry.newProfilePing.enabled", false);
 pref("toolkit.telemetry.shutdownPingSender.enabled", false);
@@ -83,6 +88,7 @@ pref("toolkit.telemetry.updatePing.enabled", false);
 pref("toolkit.telemetry.bhrPing.enabled", false);
 pref("toolkit.telemetry.firstShutdownPing.enabled", false);
 pref("toolkit.telemetry.coverage.opt-out", true);
+pref("toolkit.coverage.opt-out", true);
 pref("toolkit.coverage.endpoint.base", "");
 pref("browser.discovery.enabled", false);
 pref("breakpad.reportURL", "");
@@ -111,6 +117,9 @@ pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons", false);
 pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features", false);
 pref("extensions.htmlaboutaddons.recommendations.enabled", false);
 pref("extensions.getAddons.showPane", false);
+
+// Disable System Addon updates
+pref("extensions.systemAddon.update.url", "");
 
 /** HOMEPAGE ***/
 pref("startup.homepage_override_url", "");

--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -4,9 +4,11 @@
 
 // This file contains branding-specific prefs.
 
-pref("startup.homepage_override_url", "");
-pref("startup.homepage_welcome_url", "");
-pref("startup.homepage_welcome_url.additional", "");
+/****************************************************************************
+ * SECTION: ENABLE GHOSTERY-SPECIFIC PREFS                                  *
+****************************************************************************/
+
+/** UPDATES ***/
 // The time interval between checks for a new version (in seconds)
 pref("app.update.interval", 86400); // 24 hours
 // Give the user x seconds to react before showing the big UI. default=24 hours
@@ -17,39 +19,35 @@ pref("app.update.url.manual", "https://www.ghostery.com/download/");
 // A default value for the "More information about this update" link
 // supplied in the "An update is available" page of the update wizard.
 pref("app.update.url.details", "https://www.ghostery.com/%LOCALE%/browser/notes");
-
-// Disable System Addon updates
-pref("extensions.systemAddon.update.url", "");
-
 // The number of days a binary is permitted to be old
 // without checking for an update.  This assumes that
 // app.update.checkInstallTime is true.
 pref("app.update.checkInstallTime.days", 63);
-
 // Give the user x seconds to reboot before showing a badge on the hamburger
 // button. default=immediately
 pref("app.update.badgeWaitTime", 0);
 
-// Number of usages of the web console.
-// If this is less than 5, then pasting code into the web console is disabled
-pref("devtools.selfxss.count", 5);
+/** VARIOUS ***/
+// Fetch shavar updates from Ghostery endpoint
+pref("browser.safebrowsing.provider.mozilla.updateURL", "https://get.ghosterybrowser.com/shavar/downloads?client=SAFEBROWSING_ID&pver=2.2");
 
-/** Anti-tracking settings */
-// tracker storage partitioning - currently undocumented setting to partition browser storage for trackers in 3rd party contexts.
-// See https://bugzilla.mozilla.org/show_bug.cgi?id=1549587
-pref("network.cookie.cookieBehavior", 5);
-// origin trimming - controls how much referrer to send across origins, 2 = only send the origin
-// https://wiki.mozilla.org/Security/Referrer
-pref("network.http.referer.XOriginTrimmingPolicy", 2);
-// samesite cookies - lax by default. Protects against CSRF attacks
-// https://hacks.mozilla.org/2020/08/changes-to-samesite-cookie-behavior/
-pref("network.cookie.sameSite.laxByDefault", true);
-pref("network.cookie.sameSite.noneRequiresSecure", true);
-// redirect tracking protection - purges tracker cookies for domains with no first-party interactions.
-// https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Privacy/Redirect_Tracking_Protection
-pref("privacy.purge_trackers.enabled", true);
+// UA compat mode - Adds Firefox/VER to the UA string in addition to the APP_NAME. (https://github.com/ghostery/user-agent-desktop/issues/114)
+pref("general.useragent.compatMode.firefox", true);
 
-// disable tracking protection blocking
+// Support and feedback URLs
+pref("app.support.baseURL", "https://get.ghosterybrowser.com/support/");
+pref("app.feedback.baseURL", "https://www.ghostery.com/support/");
+
+// Override settings server to Ghostery
+pref("services.settings.server", "https://get.ghosterybrowser.com/settings/v1");
+
+
+/****************************************************************************
+ * SECTION: DISABLE MOZILLA FIREFOX-SPECIFIC PREFS                          *
+****************************************************************************/
+
+/** TRACKING ***/
+// Disable Firefox's native tracking protection blocking
 pref("browser.contentblocking.category", "custom");
 pref("privacy.trackingprotection.enabled", false);
 pref("privacy.trackingprotection.pbmode.enabled", false);
@@ -58,116 +56,73 @@ pref("privacy.trackingprotection.fingerprinting.enabled", false);
 pref("privacy.trackingprotection.socialtracking.enabled", false);
 pref("privacy.socialtracking.block_cookies.enabled", false);
 
-/* 0320: disable about:addons' Recommendations pane (uses Google Analytics) ***/
-pref("extensions.getAddons.showPane", false); // [HIDDEN PREF]
-// Recommendations in about:addons' addons pane.
-pref("extensions.htmlaboutaddons.recommendations.enabled", false);
-
-/* 0330: disable telemetry
- * the pref (.unified) affects the behaviour of the pref (.enabled)
- * IF unified=false then .enabled controls the telemetry module
- * IF unified=true then .enabled ONLY controls whether to record extended data
- * so make sure to have both set as false
- * [NOTE] FF58+ 'toolkit.telemetry.enabled' is now LOCKED to reflect prerelease
- * or release builds (true and false respectively), see [2]
- * [1] https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/internals/preferences.html
- * [2] https://medium.com/georg-fritzsche/data-preference-changes-in-firefox-58-2d5df9c428b5 ***/
-pref("toolkit.telemetry.unified", false);
-pref("toolkit.telemetry.enabled", false); // see [NOTE] above FF58+
-pref("toolkit.telemetry.server", "data:,");
-pref("toolkit.telemetry.archive.enabled", false);
-pref("toolkit.telemetry.newProfilePing.enabled", false); // [FF55+]
-pref("toolkit.telemetry.shutdownPingSender.enabled", false); // [FF55+]
-pref("toolkit.telemetry.updatePing.enabled", false); // [FF56+]
-pref("toolkit.telemetry.bhrPing.enabled", false); // [FF57+] Background Hang Reporter
-pref("toolkit.telemetry.firstShutdownPing.enabled", false); // [FF57+]
- /* 0331: disable Telemetry Coverage
-  * [1] https://blog.mozilla.org/data/2018/08/20/effectively-measuring-search-in-firefox/ ***/
-pref("toolkit.telemetry.coverage.opt-out", true); // [HIDDEN PREF]
-pref("toolkit.coverage.opt-out", true); // [FF64+] [HIDDEN PREF]
-pref("toolkit.coverage.endpoint.base", "");
- /* 0340: disable Health Reports
-  * [SETTING] Privacy & Security>Firefox Data Collection & Use>Allow Firefox to send technical... data ***/
-pref("datareporting.healthreport.uploadEnabled", false);
- /* 0341: disable new data submission, master kill switch [FF41+]
-  * If disabled, no policy is shown or upload takes place, ever
-  * [1] https://bugzilla.mozilla.org/1195552 ***/
-pref("datareporting.policy.dataSubmissionEnabled", false);
- /* 0342: disable Studies (see 0503)
-  * [SETTING] Privacy & Security>Firefox Data Collection & Use>Allow Firefox to install and run studies ***/
-pref("app.shield.optoutstudies.enabled", false);
- /* 0343: disable personalized Extension Recommendations in about:addons and AMO [FF65+]
-  * [NOTE] This pref has no effect when Health Reports (0340) are disabled
-  * [SETTING] Privacy & Security>Firefox Data Collection & Use>Allow Firefox to make personalized extension recommendations
-  * [1] https://support.mozilla.org/kb/personalized-extension-recommendations ***/
-pref("browser.discovery.enabled", false);
- /* 0350: disable Crash Reports ***/
-pref("breakpad.reportURL", "");
-pref("browser.tabs.crashReporting.sendReport", false); // [FF44+]
-pref("browser.crashReports.unsubmittedCheck.enabled", false); // [FF51+]
- /* 0351: disable backlogged Crash Reports
-  * [SETTING] Privacy & Security>Firefox Data Collection & Use>Allow Firefox to send backlogged crash reports  ***/
-pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false); // [FF58+]
-
-/* Disable Firefox-specifc menus: Pocket, Sync, What's new */
-pref("browser.messaging-system.whatsNewPanel.enabled", false); // What's New [FF69+]
-pref("extensions.pocket.enabled", false); // Pocket Account [FF46+]
-pref("identity.fxaccounts.enabled", false); // Firefox Accounts & Sync [FF60+] [RESTART]
-
-// UA compat mode - Adds Firefox/VER to the UA string in addition to the APP_NAME. (https://github.com/ghostery/user-agent-desktop/issues/114)
-pref("general.useragent.compatMode.firefox", true);
-
-// Recommend extensions/features as you browse
-pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features", false);
-pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons", false);
-
 // Remove addons.mozilla.org from set of domains that extensions cannot access
 pref("extensions.webextensions.restrictedDomains", "accounts-static.cdn.mozilla.net,accounts.firefox.com,addons.cdn.mozilla.net,api.accounts.firefox.com,content.cdn.mozilla.net,discovery.addons.mozilla.org,install.mozilla.org,oauth.accounts.firefox.com,profile.accounts.firefox.com,support.mozilla.org,sync.services.mozilla.com");
 
-// Support and feedback URLs
-pref("app.support.baseURL", "https://get.ghosterybrowser.com/support/");
-pref("app.feedback.baseURL", "https://www.ghostery.com/support/");
-
-// Override settings server to our own one
-pref("services.settings.server", "https://get.ghosterybrowser.com/settings/v1");
-
-// Disable extension abuse reporting (#186)
+/** TELEMETRY, STUDIES, EXPERIMENTS, CRASH REPORTS ***/
+// See https://github.com/yokoffing/Better-Fox/blob/a458e14a94ff67111868178639c188a5d08f7038/SecureFox.js#L510
+// for details.
+// [NOTE] We may need re-enable and/or redirect some of these for Ghostery Dawn.
+pref("datareporting.policy.dataSubmissionEnabled", false);
+pref("datareporting.healthreport.uploadEnabled", false);
+pref("browser.ping-centre.telemetry", false);
+pref("default-browser-agent.enabled", false);
+pref("app.shield.optoutstudies.enabled", false);
+pref("app.normandy.enabled", false);
+pref("app.normandy.api_url", "");
+pref("toolkit.telemetry.unified", false);
+pref("toolkit.telemetry.enabled", false);
+pref("toolkit.telemetry.archive.enabled", false);
+pref("toolkit.telemetry.newProfilePing.enabled", false);
+pref("toolkit.telemetry.shutdownPingSender.enabled", false);
+pref("toolkit.telemetry.updatePing.enabled", false);
+pref("toolkit.telemetry.bhrPing.enabled", false);
+pref("toolkit.telemetry.firstShutdownPing.enabled", false);
+pref("toolkit.telemetry.coverage.opt-out", true);
+pref("toolkit.coverage.endpoint.base", "");
+pref("browser.discovery.enabled", false);
+pref("breakpad.reportURL", "");
+pref("browser.tabs.crashReporting.sendReport", false);
+pref("browser.crashReports.unsubmittedCheck.enabled", false);
+pref("browser.crashReports.unsubmittedCheck.autoSubmit2", false);
 pref("extensions.abuseReport.enabled", false);
+pref("corroborator.enabled", false)
 
-// Disable about:welcome page
+// Disable Firefox-specifc menus and products
+pref("browser.privatebrowsing.vpnpromourl", ""); // Mozilla VPN
+pref("browser.messaging-system.whatsNewPanel.enabled", false); // What's New
+pref("extensions.pocket.enabled", false); // Pocket Account
+pref("extensions.pocket.api"," ");
+pref("extensions.pocket.oAuthConsumerKey", " ");
+pref("extensions.pocket.site", " ");
+pref("identity.fxaccounts.enabled", false); // Firefox Accounts & Sync [FF60+] [RESTART]
+pref("extensions.fxmonitor.enabled", false); // Firefox Monitor
+pref("signon.management.page.breach-alerts.enabled", false); // Firefox Lockwise
+pref("signon.management.page.breachAlertUrl", "");
+// PREF: Disable Extension Recommendations (CFR: "Contextual Feature Recommender")
+// [1] https://support.mozilla.org/en-US/kb/extension-recommendations
+pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons", false);
+pref("browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features", false);
+pref("extensions.htmlaboutaddons.recommendations.enabled", false);
+pref("extensions.getAddons.showPane", false);
+
+/** HOMEPAGE ***/
+pref("startup.homepage_override_url", "");
+pref("startup.homepage_welcome_url", "");
+pref("startup.homepage_welcome_url.additional", "");
 pref("browser.aboutwelcome.enabled", false);
 
-// Disable activity stream (#131)
+/** NEW TAB PAGE & ACTIVITY STREAM ***/
+pref("browser.startup.page", 3);
 pref("browser.library.activity-stream.enabled", false);
 pref("browser.newtabpage.activity-stream.discoverystream.enabled", false);
-
-// Disable corroborator (#141)
-pref("corroborator.enabled", false);
-
-// Disable password breach alerts
-pref("signon.management.page.breach-alerts.enabled", false);
-
-// Disable Firefox VPN promo
-pref("browser.privatebrowsing.vpnpromourl", "");
-
-// Disable dropdown suggestions with empty query
-pref("browser.urlbar.suggest.topsites", false);
-
-// Fetch shavar updates from Ghostery endpoint
-pref("browser.safebrowsing.provider.mozilla.updateURL", "https://get.ghosterybrowser.com/shavar/downloads?client=SAFEBROWSING_ID&pver=2.2");
-
-// Firefox Monitor
-pref("extensions.fxmonitor.enabled", false);
-
-// Enable HTTPS only mode (#367)
-pref("dom.security.https_only_mode", true);
-
-// Microphone and camera kill switch (#370)
-pref("privacy.webrtc.globalMuteToggles", true);
-
-// Enforce Punycode for IDN to eliminate spoofing
-pref("network.IDN_show_punycode", true);
-
-// Disable DOM battery API as it's a common factor in fingerprinting
-pref("dom.battery.enabled", false);
-
+pref("browser.newtabpage.activity-stream.showSponsored", false);
+pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false);
+pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
+pref("browser.newtabpage.activity-stream.feeds.topsites", false);
+pref("browser.newtabpage.activity-stream.feeds.snippets", false);
+pref("browser.newtabpage.activity-stream.feeds.section.highlights", false);
+pref("browser.newtabpage.activity-stream.section.highlights.includeBookmarks", false);
+pref("browser.newtabpage.activity-stream.section.highlights.includeDownloads", false);
+pref("browser.newtabpage.activity-stream.section.highlights.includePocket", false);
+pref("browser.newtabpage.activity-stream.section.highlights.includeVisited", false);


### PR DESCRIPTION
Contents:
1) Enable Ghostery-specific branding prefs
2) Disable Firefox-specific branding prefs

We will use the future BetterFox pref file to harden Ghostery Dawn (e.g., link tracking, cookies, etc.)