### PR TITLE
Prefs: bring back mandatory defaults

### DIFF
--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -182,3 +182,7 @@ pref("browser.newtabpage.activity-stream.section.highlights.includeBookmarks", f
 pref("browser.newtabpage.activity-stream.section.highlights.includeDownloads", false);
 pref("browser.newtabpage.activity-stream.section.highlights.includePocket", false);
 pref("browser.newtabpage.activity-stream.section.highlights.includeVisited", false);
+
+// Number of usages of the web console.
+// If this is less than 5, then pasting code into the web console is disabled
+pref("devtools.selfxss.count", 5);

--- a/brands/ghostery/branding/pref/firefox-branding.js
+++ b/brands/ghostery/branding/pref/firefox-branding.js
@@ -185,4 +185,4 @@ pref("browser.newtabpage.activity-stream.section.highlights.includeVisited", fal
 
 // Number of usages of the web console.
 // If this is less than 5, then pasting code into the web console is disabled
-pref("devtools.selfxss.count", 5);
+pref("devtools.selfxss.count", 0);


### PR DESCRIPTION
The lack of `devtools.selfxss.count` causes devtools to throw errors instead of logging to console.

Fortunately it looks that's the only one we're missing from original firefox-prefs.js https://github.com/mozilla/gecko-dev/blob/release/browser/branding/official/pref/firefox-branding.js