### PR TITLE
"Disable hiding mime types" depreciated

### DIFF
--- a/brands/ghostery/branding/pref/Better-Fox.js
+++ b/brands/ghostery/branding/pref/Better-Fox.js
@@ -298,8 +298,6 @@ pref("full-screen-api.warning.timeout", -1);
 
 // always ask where to download
 pref("browser.download.useDownloadDir", false);
-// hide mime types (Options>General>Applications) not associated with a plugin
-pref("browser.download.hide_plugins_without_extensions", false);
 
 
 /** VARIOUS ***/


### PR DESCRIPTION
```
// PREF: Disable hiding mime types (Options>General>Applications) not associated with a plugin
user_pref("browser.download.hide_plugins_without_extensions", false); // default=true
```

No longer in Firefox as of v.86.