### PR TITLE
Ghostery Theme caching fix

### DIFF
--- a/patches/0022-Ghostery-Theme.patch
+++ b/patches/0022-Ghostery-Theme.patch
@@ -7,37 +7,37 @@ Subject: Ghostery Theme
  .../customizableui/CustomizeMode.jsm          |   3 +
  .../background-gradient-dark.svg              |   1 +
  .../ghostery-dynamic/background-gradient.svg  |   1 +
- .../themes/addons/ghostery-dynamic/icon.svg   |  14 +++
- .../addons/ghostery-dynamic/manifest.json     |  43 +++++++
+ .../themes/addons/ghostery-dynamic/icon.svg   |  14 ++
+ .../addons/ghostery-dynamic/manifest.json     |  43 ++++++
  browser/themes/addons/jar.mn                  |   4 +
  .../themes/shared/urlbar-searchbar.inc.css    |   3 +-
  .../global/global-extension-fields.properties |   4 +-
  toolkit/modules/LightweightThemeConsumer.jsm  |   2 +-
  .../mozapps/extensions/content/aboutaddons.js |   8 +-
- .../extensions/content/ghostery-dynamic.svg   |  21 ++++
- .../extensions/default-theme/experiment.css   | 109 ++++++++++++++++++
- .../extensions/default-theme/manifest.json    |  27 ++---
+ .../extensions/content/ghostery-dynamic.svg   |  21 +++
+ .../extensions/default-theme/experiment7.css  | 129 ++++++++++++++++++
+ .../extensions/default-theme/manifest.json    |  27 ++--
  .../extensions/internal/XPIProvider.jsm       |  25 +++-
  toolkit/mozapps/extensions/jar.mn             |   2 +
  toolkit/themes/linux/global/toolbarbutton.css |   2 +-
  toolkit/themes/osx/global/toolbarbutton.css   |   2 +-
  .../themes/windows/global/toolbarbutton.css   |   2 +-
- 19 files changed, 253 insertions(+), 22 deletions(-)
+ 19 files changed, 273 insertions(+), 22 deletions(-)
  create mode 100644 browser/themes/addons/ghostery-dynamic/background-gradient-dark.svg
  create mode 100644 browser/themes/addons/ghostery-dynamic/background-gradient.svg
  create mode 100644 browser/themes/addons/ghostery-dynamic/icon.svg
  create mode 100644 browser/themes/addons/ghostery-dynamic/manifest.json
  create mode 100644 toolkit/mozapps/extensions/content/ghostery-dynamic.svg
- create mode 100644 toolkit/mozapps/extensions/default-theme/experiment.css
+ create mode 100644 toolkit/mozapps/extensions/default-theme/experiment7.css
 
 diff --git a/browser/components/BrowserGlue.jsm b/browser/components/BrowserGlue.jsm
 index 0c73eeef2e..5a60368885 100644
 --- a/browser/components/BrowserGlue.jsm
 +++ b/browser/components/BrowserGlue.jsm
 @@ -1338,6 +1338,7 @@ BrowserGlue.prototype = {
-
+ 
      SessionStore.init();
-
+ 
 +    /*
      AddonManager.maybeInstallBuiltinAddon(
        "firefox-compact-light@mozilla.org",
@@ -47,7 +47,7 @@ index 0c73eeef2e..5a60368885 100644
        "resource://builtin-themes/alpenglow/"
      );
 +    */
-
+ 
      if (AppConstants.MOZ_NORMANDY) {
        Normandy.init();
 diff --git a/browser/components/customizableui/CustomizeMode.jsm b/browser/components/customizableui/CustomizeMode.jsm
@@ -55,7 +55,7 @@ index 16b33ae73b..5f2ba0b4a5 100644
 --- a/browser/components/customizableui/CustomizeMode.jsm
 +++ b/browser/components/customizableui/CustomizeMode.jsm
 @@ -96,9 +96,12 @@ const ALPENGLOW_THEME_ID = "firefox-alpenglow@mozilla.org";
-
+ 
  const _defaultImportantThemes = [
    DEFAULT_THEME_ID,
 +  /*
@@ -65,7 +65,7 @@ index 16b33ae73b..5f2ba0b4a5 100644
 +  */
 +  "dynamic-theme@ghostery.com",
  ];
-
+ 
  var gDraggingInToolbars;
 diff --git a/browser/themes/addons/ghostery-dynamic/background-gradient-dark.svg b/browser/themes/addons/ghostery-dynamic/background-gradient-dark.svg
 new file mode 100644
@@ -166,11 +166,11 @@ index 5aa122b2ab..83349d2279 100644
 +  content/builtin-themes/ghostery-dynamic                     (ghostery-dynamic/*.css)
 +  content/builtin-themes/ghostery-dynamic/manifest.json       (ghostery-dynamic/manifest.json)
 diff --git a/browser/themes/shared/urlbar-searchbar.inc.css b/browser/themes/shared/urlbar-searchbar.inc.css
-index ea063ea7a3..9e35e65cf3 100644
+index 9cc5b6f556..0b25631bcb 100644
 --- a/browser/themes/shared/urlbar-searchbar.inc.css
 +++ b/browser/themes/shared/urlbar-searchbar.inc.css
 @@ -28,7 +28,8 @@
-
+ 
  #urlbar-container,
  #search-container {
 -  padding-block: 3px;
@@ -178,14 +178,14 @@ index ea063ea7a3..9e35e65cf3 100644
 +  padding-block: 0px;
    margin-inline: @urlbarMarginInline@;
  }
-
+ 
 diff --git a/toolkit/locales/en-US/chrome/global/global-extension-fields.properties b/toolkit/locales/en-US/chrome/global/global-extension-fields.properties
 index 0fb1689b9f..eec3fd7cb3 100644
 --- a/toolkit/locales/en-US/chrome/global/global-extension-fields.properties
 +++ b/toolkit/locales/en-US/chrome/global/global-extension-fields.properties
 @@ -3,5 +3,5 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+ 
  # LOCALIZATION NOTE (extension.default-theme@mozilla.org.name, extension.default-theme@mozilla.org.description): This is displayed in about:addons -> Appearance
 -extension.default-theme@mozilla.org.name=Default
 -extension.default-theme@mozilla.org.description=A theme with the operating system color scheme.
@@ -196,12 +196,12 @@ index 52da2fe9a7..c13073a9d8 100644
 --- a/toolkit/modules/LightweightThemeConsumer.jsm
 +++ b/toolkit/modules/LightweightThemeConsumer.jsm
 @@ -6,7 +6,7 @@ var EXPORTED_SYMBOLS = ["LightweightThemeConsumer"];
-
+ 
  const { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
-
+ 
 -const DEFAULT_THEME_ID = "default-theme@mozilla.org";
 +const DEFAULT_THEME_ID = "__DOES_NOT_APPLY__"; // in Ghostery Browser default theme is a lightweight theme
-
+ 
  ChromeUtils.defineModuleGetter(
    this,
 diff --git a/toolkit/mozapps/extensions/content/aboutaddons.js b/toolkit/mozapps/extensions/content/aboutaddons.js
@@ -229,7 +229,7 @@ index 0ad41fd91c..8ad956c3e5 100644
 +    "chrome://mozapps/content/extensions/ghostery-dynamic.svg",
 +  ],
  ]);
-
+ 
  const PERMISSION_MASKS = {
 diff --git a/toolkit/mozapps/extensions/content/ghostery-dynamic.svg b/toolkit/mozapps/extensions/content/ghostery-dynamic.svg
 new file mode 100644
@@ -259,12 +259,12 @@ index 0000000000..223a0b63e1
 +  <rect id="Rectangle" fill="#FFFFFF" fill-rule="nonzero" x="630" y="67" width="18" height="2.67" rx="1.33" stroke="none" stroke-width="1"/>
 +</svg>
 \ No newline at end of file
-diff --git a/toolkit/mozapps/extensions/default-theme/experiment.css b/toolkit/mozapps/extensions/default-theme/experiment.css
+diff --git a/toolkit/mozapps/extensions/default-theme/experiment7.css b/toolkit/mozapps/extensions/default-theme/experiment7.css
 new file mode 100644
-index 0000000000..1ac92ef05b
+index 0000000000..83eba2e10f
 --- /dev/null
-+++ b/toolkit/mozapps/extensions/default-theme/experiment.css
-@@ -0,0 +1,109 @@
++++ b/toolkit/mozapps/extensions/default-theme/experiment7.css
+@@ -0,0 +1,129 @@
 +/* This Source Code Form is subject to the terms of the Mozilla Public
 + * License, v. 2.0. If a copy of the MPL was not distributed with this
 + * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -374,14 +374,34 @@ index 0000000000..1ac92ef05b
 +#TabsToolbar .toolbarbutton-1, #tabbrowser-arrowscrollbox::part(scrollbutton-up), #tabbrowser-arrowscrollbox::part(scrollbutton-down) {
 +  margin: 1px 0 0 0 !important;
 +}
++
++#nav-bar {
++  border-bottom: 0.5px solid rgba(0, 0, 0, 0.15);
++}
++
++#urlbar-input {
++  margin-top: -1px;
++}
++
++.close-icon {
++  opacity: 0.5;
++}
++
++.close-icon:hover {
++  opacity: 1;
++}
++
++.tab-line {
++  height: 0;
++}
 diff --git a/toolkit/mozapps/extensions/default-theme/manifest.json b/toolkit/mozapps/extensions/default-theme/manifest.json
-index 05d6e0e19a..900d8ae15b 100644
+index 05d6e0e19a..beeb290823 100644
 --- a/toolkit/mozapps/extensions/default-theme/manifest.json
 +++ b/toolkit/mozapps/extensions/default-theme/manifest.json
 @@ -7,29 +7,26 @@
      }
    },
-
+ 
 -  "name": "Default",
 -  "description": "A theme with the operating system color scheme.",
 -  "author": "Mozilla",
@@ -389,10 +409,10 @@ index 05d6e0e19a..900d8ae15b 100644
 +  "name": "Ghostery Private",
 +  "description": "",
 +  "author": "Ghostery",
-+  "version": "1.6",
-
++  "version": "1.7",
+ 
    "icons": {"32": "icon.svg"},
-
+ 
    "theme": {
 -  },
 -
@@ -425,19 +445,19 @@ index 05d6e0e19a..900d8ae15b 100644
 +  },
 +
 +  "theme_experiment": {
-+    "stylesheet": "experiment.css"
++    "stylesheet": "experiment7.css"
    }
  }
 diff --git a/toolkit/mozapps/extensions/internal/XPIProvider.jsm b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
-index 841137abf8..7f0fed3573 100644
+index 841137abf8..1ffc4effe8 100644
 --- a/toolkit/mozapps/extensions/internal/XPIProvider.jsm
 +++ b/toolkit/mozapps/extensions/internal/XPIProvider.jsm
 @@ -2477,9 +2477,14 @@ var XPIProvider = {
-
+ 
        this.maybeInstallBuiltinAddon(
          "default-theme@mozilla.org",
 -        "1.1",
-+        "1.6",
++        "1.7",
          "resource://default-theme/"
        );
 +      this.maybeInstallBuiltinAddon(
@@ -445,9 +465,9 @@ index 841137abf8..7f0fed3573 100644
 +        "1.0",
 +        "resource://builtin-themes/ghostery-dynamic/"
 +      );
-
+ 
        resolveProviderReady(Promise.all(this.startupPromises));
-
+ 
 @@ -2682,6 +2687,10 @@ var XPIProvider = {
        logger.error("startup failed", e);
        AddonManagerPrivate.recordException("XPI", "startup failed", e);
@@ -457,12 +477,12 @@ index 841137abf8..7f0fed3573 100644
 +    this.maybeUninstallBuiltinAddon("firefox-compact-dark@mozilla.org");
 +    this.maybeUninstallBuiltinAddon("firefox-alpenglow@mozilla.org");
    },
-
+ 
    /**
 @@ -2927,6 +2936,20 @@ var XPIProvider = {
      return installed;
    },
-
+ 
 +  async maybeUninstallBuiltinAddon(aID) {
 +    if (enabledScopes & BuiltInLocation.scope) {
 +      let existing = BuiltInLocation.get(aID);
@@ -481,7 +501,7 @@ index 841137abf8..7f0fed3573 100644
      return Array.from(XPIDatabase.getAddons()).filter(addon =>
        addon.dependencies.includes(aAddon.id)
 diff --git a/toolkit/mozapps/extensions/jar.mn b/toolkit/mozapps/extensions/jar.mn
-index 219ac50dab..1b92ca0ddd 100644
+index 219ac50dab..dc692b99e1 100644
 --- a/toolkit/mozapps/extensions/jar.mn
 +++ b/toolkit/mozapps/extensions/jar.mn
 @@ -23,6 +23,7 @@ toolkit.jar:
@@ -496,7 +516,7 @@ index 219ac50dab..1b92ca0ddd 100644
  % resource default-theme %content/mozapps/extensions/default-theme/
    content/mozapps/extensions/default-theme/icon.svg             (default-theme/icon.svg)
    content/mozapps/extensions/default-theme/manifest.json        (default-theme/manifest.json)
-+  content/mozapps/extensions/default-theme/experiment.css       (default-theme/experiment.css)
++  content/mozapps/extensions/default-theme/experiment7.css      (default-theme/experiment7.css)
  #endif
 diff --git a/toolkit/themes/linux/global/toolbarbutton.css b/toolkit/themes/linux/global/toolbarbutton.css
 index 910e0a64b2..b6965ead5b 100644
@@ -537,5 +557,6 @@ index 14aa94d92a..c003b40168 100644
    margin-inline-end: -8px !important;
    min-width: 14px;
    max-width: 24px;
---
+-- 
 2.30.1
+


### PR DESCRIPTION
It looks like that under some conditions default theme does not update correctly, or it does partially. 

What we observed: 
On introduction of default theme changes so users don't see parts of the theme update. If they change the theme manually, all gets into order, but only until next restart. 

My suspicion is that stylesheet defined in theme's manifest `theme_experiment` section get cached. 

So as a dirty solution we can try to rename that file on each change so there will be no risk of fetching old version from cache.