### PR TITLE
GBE 8.5.6

### DIFF
--- a/.workspace
+++ b/.workspace
@@ -1,6 +1,6 @@
 {
   "addons": {
-    "ghostery": "https://s3.amazonaws.com/ghostery-deployments/ghostery-extension/8.5.5.219182e4/ghostery-dawn-v8.5.5.219182e4.xpi",
+    "ghostery": "https://s3.amazonaws.com/ghostery-deployments/ghostery-extension/8.5.5.9982cb3f/ghostery-dawn-v8.5.5.9982cb3f.xpi",
     "ghostery-search": "https://github.com/ghostery/ghostery-search-extension/releases/download/v0.2.7/ghostery_glow-0.2.7.zip",
     "ghostery-newtab": "https://github.com/ghostery/ghostery-newtab-extension/releases/download/v0.3.2/ghostery_new_tab-0.3.2.zip"
   },


### PR DESCRIPTION
GBE 8.5.6 has passed QA on staging and is ready to be made available on the nightly channel