### PR TITLE
Fix build: pin pip-tools version

### DIFF
--- a/build/Base.dockerfile
+++ b/build/Base.dockerfile
@@ -102,7 +102,7 @@ RUN apt-get update && \
       liblzma-dev
 
 # custom
-RUN pip3 install zstandard importlib_metadata mar balrogclient
+RUN pip3 install zstandard pip-tools==5.5.0 mar balrogclient
 ADD fetch-content /builds/worker/bin/fetch-content
 # mbsdiff and mar (built from martools on linux)
 ADD mbsdiff /builds/worker/bin/mbsdiff


### PR DESCRIPTION
Build was crashing with:
```
importlib_metadata.PackageNotFoundError: No package metadata was found for importlib_metadata
```

Mozilla report: https://bugzilla.mozilla.org/show_bug.cgi?id=1698453
Mozilla fix: https://phabricator.services.mozilla.com/D108485