### PR TITLE
Fix MacOS updates

### DIFF
--- a/ci.multibranch.Jenkinsfile
+++ b/ci.multibranch.Jenkinsfile
@@ -279,7 +279,8 @@ stage('publish to github') {
 
                 unarchive mapping: ["mozilla-release/" : "artifacts"]
 
-                def artifacts = sh(returnStdout: true, script: "find artifacts -type f \\( -iname \\*.mar -o -iname *-signed.dmg -o -iname \\*.exe -o -iname \\*.tar.bz2 \\)").trim().split("\\r?\\n")
+                # ignore obj-aarch64-apple-darwin artifacts - they have been unified with grep -v obj-x86-apple-darwin
+                def artifacts = sh(returnStdout: true, script: "find artifacts -type f \\( -iname \\*.mar -o -iname *-signed.dmg -o -iname \\*.exe -o -iname \\*.tar.bz2 \\) | grep -v obj-aarch64-apple-darwin").trim().split("\\r?\\n")
 
                 withCredentials([
                     usernamePassword(
@@ -324,7 +325,8 @@ stage('publish to balrog') {
 
                 unarchive mapping: ["mozilla-release/" : "artifacts"]
 
-                def artifacts = sh(returnStdout: true, script: 'find artifacts -type f -name *.mar').trim().split("\\r?\\n")
+                # ignore obj-aarch64-apple-darwin artifacts - they have been unified with grep -v obj-x86-apple-darwin
+                def artifacts = sh(returnStdout: true, script: 'find artifacts -type f -name *.mar | grep -v obj-aarch64-apple-darwin').trim().split("\\r?\\n")
 
                 withCredentials([usernamePassword(
                     credentialsId: 'dd3e97c0-5a9c-4ba9-bf34-f0071f6c3afa',


### PR DESCRIPTION
MacOS updates got broken on nightly as ARM builds were uploaded to github and balrog instead of the x86 (unified/fat) builds.
There was no code change - the problem was always there but was not visible due to `find` command default sorting. If the x86 file was first, all was fine as second file with the same name is silently ignored (during github upload, not sure about balrog).
It may be the `find` version was updated in the docker image we are using which caused the sort order to change and that way was breaking the release pipeline.